### PR TITLE
fix: Release Workflow File from CDKTF Binding Generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - goreleaser
-    uses: ./.github/workflows/cdktf-bindings.yml
+    steps:
+      - name: Generate Bindings
+        uses: ./.github/workflows/cdktf-bindings.yml


### PR DESCRIPTION
Updates `release` workflow, to call the CDKTF Binding Generation Workflow.