### PR TITLE
Fix Property Encrypted Value / Release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 - Document in `README.md`, supported versions of Terraform, and DependencyTrack.
 
 #### FIXES
-- Using `dependencytrack_config_properties`, `dependencytrack_config_property`, or `dependencytrack_project_property`, with a `type` of `"ENCRYPTEDSTRING"`,
-	would result in the value being replaced by the placeholder value from DependencyTrack.
+- Using `dependencytrack_config_properties`, `dependencytrack_config_property`, or `dependencytrack_project_property`, with a `type` of `"ENCRYPTEDSTRING"`, would result in the value being replaced by the placeholder value from DependencyTrack.
 	- Now the current value is persisted in the statefile, across operations.
 
 ## 1.8.0
@@ -90,6 +89,10 @@
 - `dependencytrack_config_property` DataSource, to retrieve a config property.
 - `dependencytrack_config_properties` Resource, to manage multiple config properties more efficiently.
 
+#### ISSUES
+- [Fixed in `1.8.1`] Resource `dependencytrack_config_property` does not retain `value` when `type` is `"ENCRYPTEDSTRING"`.
+- [Fixed in `1.8.1`] `properties` on `dependencytrack_config_properties` Resource does not retain `value` when `type` is `"ENCRYPTEDSTRING"`.
+
 #### MISC
 - Added automated testing against Terraform `1.10.x`.
 - Disabled CDKTF binding generation, while it is not fully featured.
@@ -148,6 +151,7 @@
 #### ISSUES
 - [Fixed in `1.5.0`] Unable to delete project property within DependencyTrack, when using `dependencytrack_project_property` resource.
 - [Fixed in `1.5.0`] Updating `type` on `dependencytrack_project_property` does not recreate the resource, which is required to change the `type`.
+- [Fixed in `1.8.1`] Resource `dependencytrack_project_property` does not retain `value` when `type` is `"ENCRYPTEDSTRING"`.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 #### FIXES
 - Using `dependencytrack_config_properties`, `dependencytrack_config_property`, or `dependencytrack_project_property`, with a `type` of `"ENCRYPTEDSTRING"`, would result in the value being replaced by the placeholder value from DependencyTrack.
 	- Now the current value is persisted in the statefile, across operations.
+- Marked `description` in `dependencytrack_project_property` to account for it changing from `null` to `""`, when it is not provided.
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.8.1
+
+#### MISC
+- Document in `README.md`, supported versions of Terraform, and DependencyTrack.
+
+#### FIXES
+- Using `dependencytrack_config_properties`, `dependencytrack_config_property`, or `dependencytrack_project_property`, with a `type` of `"ENCRYPTEDSTRING"`,
+	would result in the value being replaced by the placeholder value from DependencyTrack.
+	- Now the current value is persisted in the statefile, across operations.
+
 ## 1.8.0
 
 #### FEATURES

--- a/README.md
+++ b/README.md
@@ -35,9 +35,14 @@ Uses [Terraform Plugin Framework]("https://github.com/hashicorp/terraform-plugin
 	1. Create a `ProjectProperty` on `Project_Data_Test` with `Group2`, `Name2`, `2`, `INTEGER`, `Description2`
 
 ## Contributing
-Contributions are welcome.
+Contributions are welcome, either as PR, or raising an issue to request functionality.
 
 When contributing to resources, or data sources:
 1. Implementation, with appropriate input validation.
 1. Descriptions within the Schemas, listing options if only valid options are permitted.
 1. Examples, to show how to use the new item.
+
+## Supported versions
+- Terraform: `1.0` -> `1.11`
+- DependencyTrack: `latest`
+

--- a/internal/provider/config_properties_resource.go
+++ b/internal/provider/config_properties_resource.go
@@ -114,7 +114,7 @@ func (r *configPropertiesResource) Create(ctx context.Context, req resource.Crea
 			Value:     propertyReq.Value.ValueString(),
 			Type:      propertyReq.Type.ValueString(),
 		}
-		if configProperty.Type == "ENCRYPTEDSTRING" {
+		if configProperty.Type == PropertyTypeEncryptedString {
 			encryptedStringRetention[Identity{
 				group: configProperty.GroupName,
 				name:  configProperty.Name,
@@ -146,7 +146,7 @@ func (r *configPropertiesResource) Create(ctx context.Context, req resource.Crea
 			Type:        types.StringValue(propertyRes.Type),
 			Description: types.StringValue(propertyRes.Description),
 		}
-		if propertyRes.Type == "ENCRYPTEDSTRING" {
+		if propertyRes.Type == PropertyTypeEncryptedString {
 			model.Value = types.StringValue(encryptedStringRetention[Identity{
 				group: propertyRes.GroupName,
 				name:  propertyRes.Name,
@@ -210,7 +210,7 @@ func (r *configPropertiesResource) Read(ctx context.Context, req resource.ReadRe
 			Type:        types.StringValue(configProperty.Type),
 			Description: types.StringValue(configProperty.Description),
 		}
-		if configProperty.Type == "ENCRYPTEDSTRING" {
+		if configProperty.Type == PropertyTypeEncryptedString {
 			state.Properties[idx].Value = value
 		}
 	}
@@ -248,7 +248,7 @@ func (r *configPropertiesResource) Update(ctx context.Context, req resource.Upda
 			Value:     propertyReq.Value.ValueString(),
 			Type:      propertyReq.Type.ValueString(),
 		}
-		if configProperty.Type == "ENCRYPTEDSTRING" {
+		if configProperty.Type == PropertyTypeEncryptedString {
 			encryptedStringRetention[Identity{
 				group: configProperty.GroupName,
 				name:  configProperty.Name,
@@ -279,7 +279,7 @@ func (r *configPropertiesResource) Update(ctx context.Context, req resource.Upda
 			Type:        types.StringValue(propertyRes.Type),
 			Description: types.StringValue(propertyRes.Description),
 		}
-		if propertyRes.Type == "ENCRYPTEDSTRING" {
+		if propertyRes.Type == PropertyTypeEncryptedString {
 			model.Value = types.StringValue(encryptedStringRetention[Identity{
 				group: propertyRes.GroupName,
 				name:  propertyRes.Name,

--- a/internal/provider/config_properties_resource_test.go
+++ b/internal/provider/config_properties_resource_test.go
@@ -25,12 +25,18 @@ resource "dependencytrack_config_properties" "test" {
 			name = "subject.prefix"
 			value = "TF Test"
 			type = "STRING"
+		},
+		{
+			group = "email"
+			name = "smtp.password"
+			value = "TEST_PASSWORD"
+			type = "ENCRYPTEDSTRING"
 		}
 	]
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.#", "2"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.#", "3"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.0.group", "email"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.0.name", "smtp.enabled"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.0.value", "true"),
@@ -42,6 +48,12 @@ resource "dependencytrack_config_properties" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.1.value", "TF Test"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.1.type", "STRING"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.1.description", "The Prefix Subject email to use"),
+					//
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.group", "email"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.name", "smtp.password"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.value", "TEST_PASSWORD"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.type", "ENCRYPTEDSTRING"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.description", "The optional password for the username used for authentication"),
 				),
 			},
 			// Update and Read testing
@@ -60,12 +72,18 @@ resource "dependencytrack_config_properties" "test" {
 			name = "subject.prefix"
 			value = "TF Test With Update"
 			type = "STRING"
+		},
+		{
+			group = "email"
+			name = "smtp.password"
+			value = "TEST_PASSWORD"
+			type = "ENCRYPTEDSTRING"
 		}
 	]
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.#", "2"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.#", "3"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.0.group", "email"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.0.name", "smtp.enabled"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.0.value", "false"),
@@ -77,6 +95,12 @@ resource "dependencytrack_config_properties" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.1.value", "TF Test With Update"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.1.type", "STRING"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.1.description", "The Prefix Subject email to use"),
+					//
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.group", "email"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.name", "smtp.password"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.value", "TEST_PASSWORD"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.type", "ENCRYPTEDSTRING"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.description", "The optional password for the username used for authentication"),
 				),
 			},
 		},

--- a/internal/provider/config_properties_resource_test.go
+++ b/internal/provider/config_properties_resource_test.go
@@ -76,7 +76,7 @@ resource "dependencytrack_config_properties" "test" {
 		{
 			group = "email"
 			name = "smtp.password"
-			value = "TEST_PASSWORD"
+			value = "TEST_PASSWORD_WITH_CHANGE"
 			type = "ENCRYPTEDSTRING"
 		}
 	]
@@ -98,7 +98,7 @@ resource "dependencytrack_config_properties" "test" {
 					//
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.group", "email"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.name", "smtp.password"),
-					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.value", "TEST_PASSWORD"),
+					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.value", "TEST_PASSWORD_WITH_CHANGE"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.type", "ENCRYPTEDSTRING"),
 					resource.TestCheckResourceAttr("dependencytrack_config_properties.test", "properties.2.description", "The optional password for the username used for authentication"),
 				),

--- a/internal/provider/config_property_resource.go
+++ b/internal/provider/config_property_resource.go
@@ -123,6 +123,9 @@ func (r *configPropertyResource) Create(ctx context.Context, req resource.Create
 		Type:        types.StringValue(propertyRes.Type),
 		Description: types.StringValue(propertyRes.Description),
 	}
+	if propertyRes.Type == "ENCRYPTEDSTRING" {
+		propertyState.Value = plan.Value
+	}
 
 	diags = resp.State.Set(ctx, &propertyState)
 	resp.Diagnostics.Append(diags...)
@@ -163,6 +166,9 @@ func (r *configPropertyResource) Read(ctx context.Context, req resource.ReadRequ
 		Value:       types.StringValue(configProperty.Value),
 		Type:        types.StringValue(configProperty.Type),
 		Description: types.StringValue(configProperty.Description),
+	}
+	if configProperty.Type == "ENCRYPTEDSTRING" {
+		propertyState.Value = state.Value
 	}
 	diags = resp.State.Set(ctx, &propertyState)
 	resp.Diagnostics.Append(diags...)
@@ -208,6 +214,9 @@ func (r *configPropertyResource) Update(ctx context.Context, req resource.Update
 		Value:       types.StringValue(propertyRes.Value),
 		Type:        types.StringValue(propertyRes.Type),
 		Description: types.StringValue(propertyRes.Description),
+	}
+	if propertyRes.Type == "ENCRYPTEDSTRING" {
+		state.Value = plan.Value
 	}
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -265,11 +274,13 @@ func (r *configPropertyResource) ImportState(ctx context.Context, req resource.I
 			"Within Import, unable to locate config property.",
 			"Unexpected error from: "+err.Error(),
 		)
+		return
 	}
 	propertyState := configPropertyResourceModel{
-		ID:          types.StringValue(fmt.Sprintf("%s/%s", property.GroupName, property.Name)),
-		Group:       types.StringValue(property.GroupName),
-		Name:        types.StringValue(property.Name),
+		ID:    types.StringValue(fmt.Sprintf("%s/%s", property.GroupName, property.Name)),
+		Group: types.StringValue(property.GroupName),
+		Name:  types.StringValue(property.Name),
+		// If Type == "ENCRYPTEDSTRING", then Value will be placeholder text
 		Value:       types.StringValue(property.Value),
 		Type:        types.StringValue(property.Type),
 		Description: types.StringValue(property.Description),

--- a/internal/provider/config_property_resource.go
+++ b/internal/provider/config_property_resource.go
@@ -123,7 +123,7 @@ func (r *configPropertyResource) Create(ctx context.Context, req resource.Create
 		Type:        types.StringValue(propertyRes.Type),
 		Description: types.StringValue(propertyRes.Description),
 	}
-	if propertyRes.Type == "ENCRYPTEDSTRING" {
+	if propertyRes.Type == PropertyTypeEncryptedString {
 		propertyState.Value = plan.Value
 	}
 
@@ -167,7 +167,7 @@ func (r *configPropertyResource) Read(ctx context.Context, req resource.ReadRequ
 		Type:        types.StringValue(configProperty.Type),
 		Description: types.StringValue(configProperty.Description),
 	}
-	if configProperty.Type == "ENCRYPTEDSTRING" {
+	if configProperty.Type == PropertyTypeEncryptedString {
 		propertyState.Value = state.Value
 	}
 	diags = resp.State.Set(ctx, &propertyState)
@@ -215,7 +215,7 @@ func (r *configPropertyResource) Update(ctx context.Context, req resource.Update
 		Type:        types.StringValue(propertyRes.Type),
 		Description: types.StringValue(propertyRes.Description),
 	}
-	if propertyRes.Type == "ENCRYPTEDSTRING" {
+	if propertyRes.Type == PropertyTypeEncryptedString {
 		state.Value = plan.Value
 	}
 	diags = resp.State.Set(ctx, state)

--- a/internal/provider/config_property_resource_test.go
+++ b/internal/provider/config_property_resource_test.go
@@ -24,6 +24,12 @@ resource "dependencytrack_config_property" "teststring" {
 	value = "TF Test"
 	type = "STRING"
 }
+resource "dependencytrack_config_property" "testencrypted" {
+	group = "email"
+	name = "smtp.password"
+	value = "TEST_PASSWORD"
+	type = "ENCRYPTEDSTRING"
+}
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("dependencytrack_config_property.testbool", "id", "email/smtp.enabled"),
@@ -39,6 +45,12 @@ resource "dependencytrack_config_property" "teststring" {
 					resource.TestCheckResourceAttr("dependencytrack_config_property.teststring", "value", "TF Test"),
 					resource.TestCheckResourceAttr("dependencytrack_config_property.teststring", "type", "STRING"),
 					resource.TestCheckResourceAttr("dependencytrack_config_property.teststring", "description", "The Prefix Subject email to use"),
+					//
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "group", "email"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "name", "smtp.password"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "value", "TEST_PASSWORD"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "type", "ENCRYPTEDSTRING"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "description", "The optional password for the username used for authentication"),
 				),
 			},
 			// ImportState testing
@@ -51,6 +63,12 @@ resource "dependencytrack_config_property" "teststring" {
 				ResourceName:      "dependencytrack_config_property.teststring",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				ResourceName:            "dependencytrack_config_property.testencrypted",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
 			},
 			// Update and Read testing
 			{
@@ -68,6 +86,12 @@ resource "dependencytrack_config_property" "teststring" {
 	value = "TF Test with Update"
 	type = "STRING"
 }
+resource "dependencytrack_config_property" "testencrypted" {
+	group = "email"
+	name = "smtp.password"
+	value = "TEST_PASSWORD"
+	type = "ENCRYPTEDSTRING"
+}
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("dependencytrack_config_property.testbool", "id", "email/smtp.enabled"),
@@ -83,6 +107,12 @@ resource "dependencytrack_config_property" "teststring" {
 					resource.TestCheckResourceAttr("dependencytrack_config_property.teststring", "value", "TF Test with Update"),
 					resource.TestCheckResourceAttr("dependencytrack_config_property.teststring", "type", "STRING"),
 					resource.TestCheckResourceAttr("dependencytrack_config_property.teststring", "description", "The Prefix Subject email to use"),
+					//
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "group", "email"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "name", "smtp.password"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "value", "TEST_PASSWORD"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "type", "ENCRYPTEDSTRING"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "description", "The optional password for the username used for authentication"),
 				),
 			},
 		},

--- a/internal/provider/config_property_resource_test.go
+++ b/internal/provider/config_property_resource_test.go
@@ -89,7 +89,7 @@ resource "dependencytrack_config_property" "teststring" {
 resource "dependencytrack_config_property" "testencrypted" {
 	group = "email"
 	name = "smtp.password"
-	value = "TEST_PASSWORD"
+	value = "TEST_PASSWORD_WITH_CHANGE"
 	type = "ENCRYPTEDSTRING"
 }
 `,
@@ -110,7 +110,7 @@ resource "dependencytrack_config_property" "testencrypted" {
 					//
 					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "group", "email"),
 					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "name", "smtp.password"),
-					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "value", "TEST_PASSWORD"),
+					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "value", "TEST_PASSWORD_WITH_CHANGE"),
 					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "type", "ENCRYPTEDSTRING"),
 					resource.TestCheckResourceAttr("dependencytrack_config_property.testencrypted", "description", "The optional password for the username used for authentication"),
 				),

--- a/internal/provider/project_property_resource.go
+++ b/internal/provider/project_property_resource.go
@@ -90,6 +90,7 @@ func (r *projectPropertyResource) Schema(_ context.Context, _ resource.SchemaReq
 			"description": schema.StringAttribute{
 				Description: "Description of the Project Property.",
 				Optional:    true,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/project_property_resource.go
+++ b/internal/provider/project_property_resource.go
@@ -136,7 +136,9 @@ func (r *projectPropertyResource) Create(ctx context.Context, req resource.Creat
 	plan.Project = types.StringValue(project.String())
 	plan.Group = types.StringValue(propertyRes.Group)
 	plan.Name = types.StringValue(propertyRes.Name)
-	plan.Value = types.StringValue(propertyRes.Value)
+	if propertyReq.Type != "ENCRYPTEDSTRING" {
+		plan.Value = types.StringValue(propertyRes.Value)
+	}
 	plan.Type = types.StringValue(propertyRes.Type)
 	plan.Description = types.StringValue(propertyRes.Description)
 
@@ -195,6 +197,9 @@ func (r *projectPropertyResource) Read(ctx context.Context, req resource.ReadReq
 		Type:        types.StringValue(property.Type),
 		Description: types.StringValue(property.Description),
 	}
+	if property.Type == "ENCRYPTEDSTRING" {
+		propertyState.Value = state.Value
+	}
 	diags = resp.State.Set(ctx, &propertyState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -244,6 +249,9 @@ func (r *projectPropertyResource) Update(ctx context.Context, req resource.Updat
 		Value:       types.StringValue(propertyRes.Value),
 		Type:        types.StringValue(propertyRes.Type),
 		Description: types.StringValue(propertyRes.Description),
+	}
+	if propertyRes.Type == "ENCRYPTEDSTRING" {
+		state.Value = plan.Value
 	}
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/project_property_resource.go
+++ b/internal/provider/project_property_resource.go
@@ -136,7 +136,7 @@ func (r *projectPropertyResource) Create(ctx context.Context, req resource.Creat
 	plan.Project = types.StringValue(project.String())
 	plan.Group = types.StringValue(propertyRes.Group)
 	plan.Name = types.StringValue(propertyRes.Name)
-	if propertyReq.Type != "ENCRYPTEDSTRING" {
+	if propertyReq.Type != PropertyTypeEncryptedString {
 		plan.Value = types.StringValue(propertyRes.Value)
 	}
 	plan.Type = types.StringValue(propertyRes.Type)
@@ -197,7 +197,7 @@ func (r *projectPropertyResource) Read(ctx context.Context, req resource.ReadReq
 		Type:        types.StringValue(property.Type),
 		Description: types.StringValue(property.Description),
 	}
-	if property.Type == "ENCRYPTEDSTRING" {
+	if property.Type == PropertyTypeEncryptedString {
 		propertyState.Value = state.Value
 	}
 	diags = resp.State.Set(ctx, &propertyState)
@@ -250,7 +250,7 @@ func (r *projectPropertyResource) Update(ctx context.Context, req resource.Updat
 		Type:        types.StringValue(propertyRes.Type),
 		Description: types.StringValue(propertyRes.Description),
 	}
-	if propertyRes.Type == "ENCRYPTEDSTRING" {
+	if propertyRes.Type == PropertyTypeEncryptedString {
 		state.Value = plan.Value
 	}
 	diags = resp.State.Set(ctx, state)

--- a/internal/provider/project_property_resource_test.go
+++ b/internal/provider/project_property_resource_test.go
@@ -86,7 +86,7 @@ resource "dependencytrack_project_property" "testencrypted" {
 	project = dependencytrack_project.test.id
 	group = "G-Enc"
 	name = "N-Enc"
-	value = "TEST_ENCRYPTED_VALUE"
+	value = "TEST_ENCRYPTED_VALUE_WITH_CHANGE"
 	type = "ENCRYPTEDSTRING"
 	description = "D-Enc"
 }
@@ -109,7 +109,7 @@ resource "dependencytrack_project_property" "testencrypted" {
 					),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "group", "G-Enc"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "name", "N-Enc"),
-					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "value", "TEST_ENCRYPTED_VALUE"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "value", "TEST_ENCRYPTED_VALUE_WITH_CHANGE"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "type", "ENCRYPTEDSTRING"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "description", "D-Enc"),
 				),

--- a/internal/provider/project_property_resource_test.go
+++ b/internal/provider/project_property_resource_test.go
@@ -24,6 +24,14 @@ resource "dependencytrack_project_property" "test" {
 	type = "STRING"
 	description = "D"
 }
+resource "dependencytrack_project_property" "testencrypted" {
+	project = dependencytrack_project.test.id
+	group = "G-Enc"
+	name = "N-Enc"
+	value = "TEST_ENCRYPTED_VALUE"
+	type = "ENCRYPTEDSTRING"
+	description = "D-Enc"
+}
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("dependencytrack_project_property.test", "id"),
@@ -36,6 +44,16 @@ resource "dependencytrack_project_property" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_project_property.test", "value", "C"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.test", "type", "STRING"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.test", "description", "D"),
+					//
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_project_property.testencrypted", "project",
+						"dependencytrack_project.test", "id",
+					),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "group", "G-Enc"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "name", "N-Enc"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "value", "TEST_ENCRYPTED_VALUE"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "type", "ENCRYPTEDSTRING"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "description", "D-Enc"),
 				),
 			},
 			// ImportState testing
@@ -43,6 +61,12 @@ resource "dependencytrack_project_property" "test" {
 				ResourceName:      "dependencytrack_project_property.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				ResourceName:            "dependencytrack_project_property.testencrypted",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
 			},
 			// Update and Read testing
 			{
@@ -58,6 +82,14 @@ resource "dependencytrack_project_property" "test" {
 	type = "INTEGER"
 	description = "D"
 }
+resource "dependencytrack_project_property" "testencrypted" {
+	project = dependencytrack_project.test.id
+	group = "G-Enc"
+	name = "N-Enc"
+	value = "TEST_ENCRYPTED_VALUE"
+	type = "ENCRYPTEDSTRING"
+	description = "D-Enc"
+}
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("dependencytrack_project_property.test", "id"),
@@ -70,6 +102,16 @@ resource "dependencytrack_project_property" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_project_property.test", "value", "2"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.test", "type", "INTEGER"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.test", "description", "D"),
+					//
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_project_property.testencrypted", "project",
+						"dependencytrack_project.test", "id",
+					),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "group", "G-Enc"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "name", "N-Enc"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "value", "TEST_ENCRYPTED_VALUE"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "type", "ENCRYPTEDSTRING"),
+					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "description", "D-Enc"),
 				),
 			},
 		},

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+
 	dtrack "github.com/DependencyTrack/client-go"
 	"github.com/google/uuid"
 )

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const PropertyTypeEncryptedString = "ENCRYPTEDSTRING"
+
 func Filter[T any](items []T, filter func(T) bool) []T {
 	filtered := []T{}
 	for _, item := range items {


### PR DESCRIPTION
## See CHANGELOG for list of changes
- Add tests for property resources, with `type` of `ENCRYPTEDSTRING`, due to having different handling in `API`.
- Update logic to fix handling, to be able to work with tests.
- Document supported versions.