### PR TITLE
UUID Parsing Errors / Release 1.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ website/vendor
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+
+terraform-provider-dependencytrack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.12.1
+
+#### FIXES
+- Within Update `comment` on `dependencytrack_team_apikey` was not being written back to state using return value from DependencyTrack.
+- Witin Create, Update, the permission list was assigned from a `dtrack.Team`, which may have been `nil`.
+
+#### MISC
+- Standardised log error reporting when failing to parse a `UUID`.
+
 ## 1.12.0
 
 #### FEATURES
@@ -62,6 +71,9 @@
 
 #### FEATURES
 - Add `dependencytrack_team_permissions` resource to canonically manage the permissions assigned to a Team.
+
+#### ISSUES
+- [Fixed in `1.12.1`]: Permission list is assigned from a potentially `nil` `dtrack.Team`.
 
 #### MISC
 - Remove deprecated field from within `golangci` config file for `goconst`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 #### FIXES
 - Within Update `comment` on `dependencytrack_team_apikey` was not being written back to state using return value from DependencyTrack.
-- Witin Create, Update, the permission list was assigned from a `dtrack.Team`, which may have been `nil`.
+- Within Create, Update, the permission list was assigned from a `dtrack.Team`, which may have been `nil`.
+- Within Import, `dependencytrack_acl_mapping` would still write to state if unable regardless of whether UUIDs parsed successfully.
 
 #### MISC
 - Standardised log error reporting when failing to parse a `UUID`.
@@ -19,6 +20,9 @@
 
 #### FEATURES
 - Add `dependencytrack_acl_mapping` resource to manage Portfolio Access Control for Projects.
+
+#### ISSUES
+- [Fixed in `1.12.1`] Import of `dependencytrack_acl_mapping` would import regardless of whether UUIDs parsed successfully.
 
 #### DEPENDENCIES
 - `github.com/DependencyTrack/client-go` `0.16.0` -> `main`
@@ -73,7 +77,7 @@
 - Add `dependencytrack_team_permissions` resource to canonically manage the permissions assigned to a Team.
 
 #### ISSUES
-- [Fixed in `1.12.1`]: Permission list is assigned from a potentially `nil` `dtrack.Team`.
+- [Fixed in `1.12.1`] Permission list is assigned from a potentially `nil` `dtrack.Team`.
 
 #### MISC
 - Remove deprecated field from within `golangci` config file for `goconst`.

--- a/internal/provider/policy_project_resource.go
+++ b/internal/provider/policy_project_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
 
 	dtrack "github.com/DependencyTrack/client-go"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -67,21 +66,13 @@ func (r *policyProjectResource) Create(ctx context.Context, req resource.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	policyId, err := uuid.Parse(plan.PolicyID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("policy"),
-			"Within Create, unable to parse policy into UUID",
-			"Error from: "+err.Error(),
-		)
+	policyId, diag := TryParseUUID(plan.PolicyID, LifecycleCreate, path.Root("policy"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
-	projectId, err := uuid.Parse(plan.ProjectID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("project"),
-			"Within Create, unable to parse project into UUID",
-			"Error from: "+err.Error(),
-		)
+	projectId, diag := TryParseUUID(plan.ProjectID, LifecycleCreate, path.Root("project"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -121,21 +112,13 @@ func (r *policyProjectResource) Read(ctx context.Context, req resource.ReadReque
 	tflog.Debug(ctx, "Refreshing policy-project mapping for policy: "+state.PolicyID.ValueString()+", and project: "+state.ProjectID.ValueString())
 
 	// Refresh
-	policyId, err := uuid.Parse(state.PolicyID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("policy"),
-			"Within Read, unable to parse policy into UUID",
-			"Error from: "+err.Error(),
-		)
+	policyId, diag := TryParseUUID(state.PolicyID, LifecycleRead, path.Root("policy"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
-	projectId, err := uuid.Parse(state.ProjectID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("project"),
-			"Within Read, unable to parse project into UUID",
-			"Error from: "+err.Error(),
-		)
+	projectId, diag := TryParseUUID(state.ProjectID, LifecycleRead, path.Root("project"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -182,21 +165,14 @@ func (r *policyProjectResource) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	policyId, err := uuid.Parse(plan.PolicyID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("policy"),
-			"Within Update, unable to parse policy into UUID",
-			"Error from: "+err.Error(),
-		)
+
+	policyId, diag := TryParseUUID(plan.PolicyID, LifecycleUpdate, path.Root("policy"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
-	projectId, err := uuid.Parse(plan.ProjectID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("project"),
-			"Within Update, unable to parse project into UUID",
-			"Error from: "+err.Error(),
-		)
+	projectId, diag := TryParseUUID(plan.ProjectID, LifecycleUpdate, path.Root("project"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -224,28 +200,21 @@ func (r *policyProjectResource) Delete(ctx context.Context, req resource.DeleteR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	policyId, err := uuid.Parse(state.PolicyID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("policy"),
-			"Within Delete, unable to parse policy into UUID",
-			"Error from: "+err.Error(),
-		)
+
+	policyId, diag := TryParseUUID(state.PolicyID, LifecycleDelete, path.Root("policy"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
-	projectId, err := uuid.Parse(state.ProjectID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("project"),
-			"Within Delete, unable to parse project into UUID",
-			"Error from: "+err.Error(),
-		)
+	projectId, diag := TryParseUUID(state.ProjectID, LifecycleDelete, path.Root("project"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	tflog.Debug(ctx, "Deleting project-policy mapping for policy: "+policyId.String()+", with project: "+projectId.String())
-	_, err = r.client.Policy.DeleteProject(ctx, policyId, projectId)
+	_, err := r.client.Policy.DeleteProject(ctx, policyId, projectId)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to delete project-policy mapping",

--- a/internal/provider/project_property_data_source.go
+++ b/internal/provider/project_property_data_source.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	dtrack "github.com/DependencyTrack/client-go"
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -85,13 +84,9 @@ func (d *projectPropertyDataSource) Read(ctx context.Context, req datasource.Rea
 		"group":   state.Group.ValueString(),
 		"name":    state.Name.ValueString(),
 	})
-	uuid, err := uuid.Parse(state.Project.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("id"),
-			"Within Read, unable to parse id into UUID",
-			"Error from: "+err.Error(),
-		)
+	uuid, diag := TryParseUUID(state.Project, LifecycleRead, path.Root("id"))
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 		return
 	}
 	property, err := FindPaged(

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -10,6 +10,9 @@ import (
 
 	dtrack "github.com/DependencyTrack/client-go"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type Semver struct {
@@ -190,4 +193,35 @@ func Map[T, U any](items []T, actor func(T) U) []U {
 		result = append(result, u)
 	}
 	return result
+}
+
+type LifecycleAction string
+
+const (
+	LifecycleCreate LifecycleAction = "Create" //LifecycleAction{"Create"}
+	LifecycleRead   LifecycleAction = "Read"   //LifecycleAction{"Read"}
+	LifecycleUpdate LifecycleAction = "Update" //LifecycleAction{"Update"}
+	LifecycleDelete LifecycleAction = "Delete" //LifecycleAction{"Delete"}
+	LifecycleImport LifecycleAction = "Import" //LifecycleAction{"Import"}
+)
+
+func TryParseUUID(value types.String, action LifecycleAction, path path.Path) (uuid.UUID, diag.Diagnostic) {
+	if value.IsUnknown() {
+		diag := diag.NewAttributeErrorDiagnostic(
+			path,
+			fmt.Sprintf("Within %s, unable to parse %s into UUID.", action, path.String()),
+			fmt.Sprintf("Value for %s is unknown.", path.String()),
+		)
+		return uuid.Nil, diag
+	}
+	ret, err := uuid.Parse(value.ValueString())
+	if err != nil {
+		diag := diag.NewAttributeErrorDiagnostic(
+			path,
+			fmt.Sprintf("Within %s, unable to parse %s into UUID.", action, path.String()),
+			"Error from: "+err.Error(),
+		)
+		return uuid.Nil, diag
+	}
+	return ret, nil
 }

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -198,11 +198,11 @@ func Map[T, U any](items []T, actor func(T) U) []U {
 type LifecycleAction string
 
 const (
-	LifecycleCreate LifecycleAction = "Create" //LifecycleAction{"Create"}
-	LifecycleRead   LifecycleAction = "Read"   //LifecycleAction{"Read"}
-	LifecycleUpdate LifecycleAction = "Update" //LifecycleAction{"Update"}
-	LifecycleDelete LifecycleAction = "Delete" //LifecycleAction{"Delete"}
-	LifecycleImport LifecycleAction = "Import" //LifecycleAction{"Import"}
+	LifecycleCreate LifecycleAction = "Create"
+	LifecycleRead   LifecycleAction = "Read"
+	LifecycleUpdate LifecycleAction = "Update"
+	LifecycleDelete LifecycleAction = "Delete"
+	LifecycleImport LifecycleAction = "Import"
 )
 
 func TryParseUUID(value types.String, action LifecycleAction, path path.Path) (uuid.UUID, diag.Diagnostic) {
@@ -211,6 +211,14 @@ func TryParseUUID(value types.String, action LifecycleAction, path path.Path) (u
 			path,
 			fmt.Sprintf("Within %s, unable to parse %s into UUID.", action, path.String()),
 			fmt.Sprintf("Value for %s is unknown.", path.String()),
+		)
+		return uuid.Nil, diag
+	}
+	if value.IsNull() {
+		diag := diag.NewAttributeErrorDiagnostic(
+			path,
+			fmt.Sprintf("Within %s, unable to parse %s into UUID.", action, path.String()),
+			fmt.Sprintf("Value for %s is null.", path.String()),
 		)
 		return uuid.Nil, diag
 	}


### PR DESCRIPTION
See CHANGELOG for complete changes.
- Release v1.12.1
- Standardise log error reporting for invalid UUID parsing.
- Fix issues
  - Response from API of updating comment not written to state within `dependencytrack_team_apikey`
  - Potentially invalid field access within `dependencytrack_team_permissions` when failing to add or remove a permission.
  - Possibility to import an invalid UUID within `dependencytrack_acl_mapping`.