### PR TITLE
Pipeline efficiency

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -7,11 +7,16 @@ inputs:
     required: true
   provider_config_key:
     description: "Config key to determine which provider config to use, as defined within provider_test.go."
-    required: true
+    required: false
+    default: "default"
   tests_skip_regex:
     description: "Regular Expression of Terraform Acceptance Tests to skip."
     required: false
     default: "^$"
+  tests_run_regex:
+    description: "Regular Expression of Terraform Acceptance Tests to run."
+    required: false
+    default: "^.*$"
 
 runs:
   using: "composite"
@@ -52,7 +57,7 @@ runs:
         terraform_wrapper: false
     - run: go mod download
       shell: bash
-    - run: go test -v -cover ./internal/provider/ -skip "${{ inputs.tests_skip_regex }}"
+    - run: go test -v -cover ./internal/provider/ -skip "${{ inputs.tests_skip_regex }}" -run "${{ inputs.tests_run_regex }}"
       shell: bash
       env:
         TF_ACC: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,25 +74,26 @@ jobs:
           - "mtls"
           - "rootCA+mtls"
         terraform:
-          - "1.0.*"
-          - "1.1.*"
-          - "1.2.*"
-          - "1.3.*"
-          - "1.4.*"
-          - "1.5.*"
-          - "1.6.*"
-          - "1.7.*"
-          - "1.8.*"
-          - "1.9.*"
-          - "1.10.*"
-          - "1.11.*"
-          - "1.12.*"
+          - '1.0.*'
+          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
+          - '1.4.*'
+          - '1.5.*'
+          - '1.6.*'
+          - '1.7.*'
+          - '1.8.*'
+          - '1.9.*'
+          - '1.10.*'
+          - '1.11.*'
+          - '1.12.*'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/test
         with:
           terraform_version: ${{ matrix.terraform }}
           provider_config_key: ${{ matrix.provider }}
+          # Arbitrarily picked test. Uses Project, as that is the primary resource within DT.
           tests_run_regex: "^TestAccProjectResource$"
 
 
@@ -135,34 +136,33 @@ jobs:
       fail-fast: false
       matrix:
         api:
-# TODO: Adjust logic according to versions to allow supporting older API versions, as required.
           - version: "4.11.7"
             skip: "^(TestAccTagResource)|(TestAccProjectTagsRead)|(TestAccTagPoliciesResource)|(TestAccTagProjectsResource)$"
-#          - version: "4.12.7"
-#            skip: "^TestAccTagResource$"
-#          - version: "4.13.0"
-#            skip: "^$"
-#          - version: "4.13.1"
-#            skip: "^$"
-#          - version: "4.13.2"
-#            skip: "^$"
-#          - version: "4.13.3"
-#            skip: "^$"
-#          - version: "4.13.4"
-#            skip: "^$"
+          - version: "4.12.7"
+            skip: "^TestAccTagResource$"
+          - version: "4.13.0"
+            skip: "^$"
+          - version: "4.13.1"
+            skip: "^$"
+          - version: "4.13.2"
+            skip: "^$"
+          - version: "4.13.3"
+            skip: "^$"
+          - version: "4.13.4"
+            skip: "^$"
         terraform:
-#          - '1.0.*'
-#          - '1.1.*'
-#          - '1.2.*'
-#          - '1.3.*'
-#          - '1.4.*'
-#          - '1.5.*'
-#          - '1.6.*'
-#          - '1.7.*'
-#          - '1.8.*'
-#          - '1.9.*'
-#          - '1.10.*'
-#          - '1.11.*'
+          - '1.0.*'
+          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
+          - '1.4.*'
+          - '1.5.*'
+          - '1.6.*'
+          - '1.7.*'
+          - '1.8.*'
+          - '1.9.*'
+          - '1.10.*'
+          - '1.11.*'
           - '1.12.*'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         api:
-          - "4.11.7"
-          - "4.12.7"
-          - "4.13.0"
-          - "4.13.1"
-          - "4.13.2"
+          # TLS Connectivity is between TF and Nginx, so is independent of API version.
+          # Full API testing is handled in subsequent jobs. Therefore, this can be the latest supported API version.
           - "4.13.3"
         provider:
           - "default"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,32 +89,32 @@ jobs:
 # TODO: Adjust logic according to versions to allow supporting older API versions, as required.
           - version: "4.11.7"
             skip: "^(TestAccTagResource)|(TestAccProjectTagsRead)|(TestAccTagPoliciesResource)|(TestAccTagProjectsResource)$"
-          - version: "4.12.7"
-            skip: "^TestAccTagResource$"
-          - version: "4.13.0"
-            skip: "^$"
-          - version: "4.13.1"
-            skip: "^$"
-          - version: "4.13.2"
-            skip: "^$"
-          - version: "4.13.3"
-            skip: "^$"
+#          - version: "4.12.7"
+#            skip: "^TestAccTagResource$"
+#          - version: "4.13.0"
+#            skip: "^$"
+#          - version: "4.13.1"
+#            skip: "^$"
+#          - version: "4.13.2"
+#            skip: "^$"
+#          - version: "4.13.3"
+#            skip: "^$"
         provider:
           - "default"
-          - "rootCA"
+#          - "rootCA"
         terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
-          - '1.5.*'
-          - '1.6.*'
-          - '1.7.*'
-          - '1.8.*'
-          - '1.9.*'
-          - '1.10.*'
-          - '1.11.*'
+#          - '1.0.*'
+#          - '1.1.*'
+#          - '1.2.*'
+#          - '1.3.*'
+#          - '1.4.*'
+#          - '1.5.*'
+#          - '1.6.*'
+#          - '1.7.*'
+#          - '1.8.*'
+#          - '1.9.*'
+#          - '1.10.*'
+#          - '1.11.*'
           - '1.12.*'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -125,6 +125,7 @@ jobs:
           tests_skip_regex: ${{ matrix.api.skip }}
 
   test_mtls:
+    if: false
     name: Terraform Provider Acceptance Tests
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,14 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
 
-  test_connect:
-    name: Terraform Provider Connection Tests
+  test_tls:
+    name: Terraform Provider TLS Tests
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
       api:
-        image: dependencytrack/apiserver:${{ matrix.api.version }}
+        image: dependencytrack/apiserver:${{ matrix.api }}
         env:
           TELEMETRY_SUBMISSION_ENABLED_DEFAULT: false
         ports:
@@ -101,7 +101,7 @@ jobs:
     name: Terraform Provider Acceptance Tests
     needs:
       - build
-      - test_connect
+      - test_tls
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,62 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
 
+  test_connect:
+    name: Terraform Provider Connection Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      api:
+        image: dependencytrack/apiserver:${{ matrix.api.version }}
+        env:
+          TELEMETRY_SUBMISSION_ENABLED_DEFAULT: false
+        ports:
+          - 8081:8080
+    strategy:
+      fail-fast: false
+      matrix:
+        api:
+          - "4.11.7"
+          - "4.12.7"
+          - "4.13.0"
+          - "4.13.1"
+          - "4.13.2"
+          - "4.13.3"
+        provider:
+          - "default"
+          - "rootCA"
+          - "mtls"
+          - "rootCA+mtls"
+        terraform:
+          - "1.0.*"
+          - "1.1.*"
+          - "1.2.*"
+          - "1.3.*"
+          - "1.4.*"
+          - "1.5.*"
+          - "1.6.*"
+          - "1.7.*"
+          - "1.8.*"
+          - "1.9.*"
+          - "1.10.*"
+          - "1.11.*"
+          - "1.12.*"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/test
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          provider_config_key: ${{ matrix.provider }}
+          tests_run_regex: "^TestAccProjectResource$"
+
+
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests
-    needs: build
+    needs:
+      - build
+      - test_connect
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -99,9 +151,6 @@ jobs:
 #            skip: "^$"
 #          - version: "4.13.3"
 #            skip: "^$"
-        provider:
-          - "default"
-#          - "rootCA"
         terraform:
 #          - '1.0.*'
 #          - '1.1.*'
@@ -121,59 +170,4 @@ jobs:
       - uses: ./.github/actions/test
         with:
           terraform_version: ${{ matrix.terraform }}
-          provider_config_key: ${{ matrix.provider }}
-          tests_skip_regex: ${{ matrix.api.skip }}
-
-  test_mtls:
-    if: false
-    name: Terraform Provider Acceptance Tests
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    services:
-      api:
-        image: dependencytrack/apiserver:${{ matrix.api.version }}
-        env:
-          TELEMETRY_SUBMISSION_ENABLED_DEFAULT: false
-        ports:
-          - 8081:8080
-    strategy:
-      fail-fast: false
-      matrix:
-        api:
-          - version: "4.11.7"
-            skip: "^(TestAccTagResource)|(TestAccProjectTagsRead)|(TestAccTagPoliciesResource)|(TestAccTagProjectsResource)$"
-          - version: "4.12.7"
-            skip: "^TestAccTagResource$"
-          - version: "4.13.0"
-            skip: "^$"
-          - version: "4.13.1"
-            skip: "^$"
-          - version: "4.13.2"
-            skip: "^$"
-          - version: "4.13.3"
-            skip: "^$"
-        provider:
-          - "mtls"
-          - "rootCA+mtls"
-        terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
-          - '1.5.*'
-          - '1.6.*'
-          - '1.7.*'
-          - '1.8.*'
-          - '1.9.*'
-          - '1.10.*'
-          - '1.11.*'
-          - '1.12.*'
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: ./.github/actions/test
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          provider_config_key: ${{ matrix.provider }}
           tests_skip_regex: ${{ matrix.api.skip }}

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module terraform-provider-dependencytrack
 
 go 1.23.0
 
-// toolchain go1.24.1
-// toolchain go1.23.0
-
 require (
 	github.com/DependencyTrack/client-go v0.17.0
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,8 @@ module terraform-provider-dependencytrack
 
 go 1.23.0
 
-toolchain go1.24.1
+// toolchain go1.24.1
+// toolchain go1.23.0
 
 require (
 	github.com/DependencyTrack/client-go v0.17.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,8 +2,6 @@ module tools
 
 go 1.23.0
 
-// toolchain go1.24.0
-
 require (
 	github.com/hashicorp/copywrite v0.19.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.23.0
 
-toolchain go1.24.0
+// toolchain go1.24.0
 
 require (
 	github.com/hashicorp/copywrite v0.19.0


### PR DESCRIPTION
- Split connectivity tests for TLS into separate job, running once for each Terraform version.
  - Uses nominal test for verifying connectivity to Nginx within pipeline.
- Reduce running all TLS configuration tests against all API and Terraform versions, to just use plain text for Terraform Tests, since TLS tests are separate.
- Effect is reducing number of jobs from 312, to 148, due to existing duplication of testing functionality.
- Remove `toolchain` directive within `go.mod`, to resolve warnings from https://github.com/actions/setup-go/issues/424.