### PR TITLE
API Support 4.14.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         api:
           # TLS Connectivity is between TF and Nginx, so is independent of API version.
           # Full API testing is handled in subsequent jobs. Therefore, this can be the latest supported API version.
-          - "4.14.1-alpine"
+          - "4.14.2-alpine"
         provider:
           - "default"
           - "rootCA"
@@ -186,6 +186,10 @@ jobs:
           - version: "4.14.1"
             skip: "^$"
           - version: "4.14.1-alpine"
+            skip: "^$"
+          - version: "4.14.2"
+            skip: "^$"
+          - version: "4.14.2-alpine"
             skip: "^$"
         terraform:
           - '1.0.*'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The latest patch version within a minor release is supported, even if it might n
 The list of API Versions will grow as functionality adapts to allow further tests to pass.
 The latest 2 patches within the latest minor version, at a minimum, will be tested, and supported to allow for continued support while migrating.
 - Terraform: `1.0` -> `1.15`
-- DependencyTrack: `4.11.7`, `4.12.7`, `4.13.0`, `4.13.1`, `4.13.2`, `4.13.3`, `4.13.4`, `4.13.5`, `4.13.6`, `4.13.6-alpine`, `4.14.0`, `4.14.0-alpine`, `4.14.1`, `4.14.1-alpine`.
+- DependencyTrack: `4.11.7`, `4.12.7`, `4.13.0`, `4.13.1`, `4.13.2`, `4.13.3`, `4.13.4`, `4.13.5`, `4.13.6`, `4.13.6-alpine`, `4.14.0`, `4.14.0-alpine`, `4.14.1`, `4.14.1-alpine`, `4.14.2`, `4.14.2-alpine`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Add testing for API `4.14.2`, `4.14.2-alpine`.
- Update list of supported versions.