### PR TITLE
Bugfix 236

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,31 +161,31 @@ jobs:
       matrix:
         api:
           - version: "4.11.7"
-            skip: "^(TestAccTagResource)|(TestAccProjectTagsRead)|(TestAccTagPoliciesResource)|(TestAccTagProjectsResource)|(TestAccProjectCollection)|(TestAccProjectIsLatest)|(TestAccProjectDataSourceIsLatest)|(TestAccNotificationRuleScheduleResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccTagResource)|(TestAccProjectTagsRead)|(TestAccTagPoliciesResource)|(TestAccTagProjectsResource)|(TestAccProjectCollection)|(TestAccProjectIsLatest)|(TestAccProjectDataSourceIsLatest)|(TestAccNotificationRuleScheduleResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.12.7"
-            skip: "^(TestAccTagResource)|(TestAccProjectCollection)|(TestAccNotificationRuleScheduleResource)|(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccTagResource)|(TestAccProjectCollection)|(TestAccNotificationRuleScheduleResource)|(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.13.0"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.13.1"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.13.2"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.13.3"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.13.4"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.13.5"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.13.6-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.14.0-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.14.1-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.14.2-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
           - version: "4.14.3-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)$"
+            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
         terraform:
           - '1.0.*'
           - '1.1.*'
@@ -244,13 +244,13 @@ jobs:
         api:
           - version: "5.0.2"
             # Currently failing tests, which will require adjusting implementation to properly fix.
-            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)$"
+            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccNotificationRuleResourceRegression236)$"
           - version: "5.0.5"
             # Currently failing tests, which will require adjusting implementation to properly fix.
-            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)$"
+            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccNotificationRuleResourceRegression236)$"
           - version: "5.1.0"
             # Currently failing tests, which will require adjusting implementation to properly fix.
-            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)$"
+            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccNotificationRuleResourceRegression236)$"
         terraform:
           - '1.0.*'
           - '1.1.*'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,6 +100,7 @@ linters:
       ignore-patterns:
         - "^github.com/hashicorp/terraform-plugin-testing/helper/resource\\.TestCase$"
         - "^github.com/hashicorp/terraform-plugin-testing/helper/resource\\.TestStep$"
+        - "^github.com/hashicorp/terraform-plugin-testing/helper/resource\\.ConfigPlanChecks$"
         - "^github.com/hashicorp/terraform-plugin-framework/resource/schema\\.Schema$"
         - "^github.com/hashicorp/terraform-plugin-framework/resource/schema\\.StringAttribute$"
         - "^github.com/hashicorp/terraform-plugin-framework/resource/schema\\.BoolAttribute$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -626,6 +626,20 @@ linters:
       - path: internal/provider/vulnerability_policy_resource_test.go
         linters:
           - cyclop
+      - path: internal/provider/ldap_team_mapping_resource.go
+        linters:
+          - godox
+      - path: internal/provider/policy_project_resource.go
+        linters:
+          - godox
+      - path: internal/provider/tag_resource.go
+        linters:
+          - godox
+          - revive
+          - lll
+      - path: internal/provider/user_team_resource.go
+        linters:
+          - godox
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -646,6 +646,9 @@ linters:
       - path: internal/provider/notification_rule_team_resource.go
         linters:
           - gocognit
+      - path: internal/provider/user_permission_resource.go
+        linters:
+          - godox
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -640,6 +640,12 @@ linters:
       - path: internal/provider/user_team_resource.go
         linters:
           - godox
+      - path: internal/provider/notification_rule_project_resource.go
+        linters:
+          - gocognit
+      - path: internal/provider/notification_rule_team_resource.go
+        linters:
+          - gocognit
 
 formatters:
   enable:

--- a/internal/provider/acl_mapping_resource.go
+++ b/internal/provider/acl_mapping_resource.go
@@ -261,13 +261,20 @@ func (r *aclMappingResource) Delete(ctx context.Context, req resource.DeleteRequ
 		"team":    team.String(),
 		"project": project.String(),
 	})
-	// Deletion of non-existent ACL mapping is 200 OK, (against API 5.1.0).
-	// TODO: Write test for this, as may not be the same in API v4.
 	err := r.client.ACL.RemoveProjectMapping(ctx, team, project)
 	if err != nil {
+		err := err.Error()
+		// Deletion of non-existent ACL mapping is 200 OK within API v5.x
+		if r.semver.Major == 4 && err == "The UUID of the team or project could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing ACL Mapping. Ignoring since in desired state.", map[string]any{
+				"project": state.Project.ValueString(),
+				"team":    state.Team.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete acl mapping",
-			"Unexpected error when trying to delete acl mapping, from error: "+err.Error(),
+			"Unexpected error when trying to delete acl mapping, from error: "+err,
 		)
 		return
 	}

--- a/internal/provider/acl_mapping_resource.go
+++ b/internal/provider/acl_mapping_resource.go
@@ -158,9 +158,18 @@ func (r *aclMappingResource) Read(ctx context.Context, req resource.ReadRequest,
 	})
 
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to get missing ACL mapping when attempting to read. Will be removed from state.", map[string]any{
+				"team":    teamID.String(),
+				"project": projectID.String(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to get ACL mapping within Read",
-			"Error with reading acl mapping for team: "+teamID.String()+", and project: "+projectID.String()+", in original error: "+err.Error(),
+			"Error with reading acl mapping for team: "+teamID.String()+", and project: "+projectID.String()+", in original error: "+err,
 		)
 		return
 	}
@@ -252,6 +261,8 @@ func (r *aclMappingResource) Delete(ctx context.Context, req resource.DeleteRequ
 		"team":    team.String(),
 		"project": project.String(),
 	})
+	// Deletion of non-existent ACL mapping is 200 OK, (against API 5.1.0).
+	// TODO: Write test for this, as may not be the same in API v4.
 	err := r.client.ACL.RemoveProjectMapping(ctx, team, project)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/acl_mapping_resource.go
+++ b/internal/provider/acl_mapping_resource.go
@@ -264,7 +264,7 @@ func (r *aclMappingResource) Delete(ctx context.Context, req resource.DeleteRequ
 	err := r.client.ACL.RemoveProjectMapping(ctx, team, project)
 	if err != nil {
 		err := err.Error()
-		// Deletion of non-existent ACL mapping is 200 OK within API v5.x
+		// Deletion of non-existent ACL mapping is 200 OK within API v5.x.
 		if r.semver.Major == 4 && err == "The UUID of the team or project could not be found. (status: 404)" {
 			tflog.Warn(ctx, "Unable to delete missing ACL Mapping. Ignoring since in desired state.", map[string]any{
 				"project": state.Project.ValueString(),

--- a/internal/provider/acl_mapping_resource_test.go
+++ b/internal/provider/acl_mapping_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccAclMappingResource(t *testing.T) {
@@ -70,6 +71,80 @@ resource "dependencytrack_acl_mapping" "test" {
 						"dependencytrack_acl_mapping.test", "team",
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAclMappingResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial ACL
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ACL_Project_236"
+}
+resource "dependencytrack_team" "test" {
+	name = "Test_ACL_Team_236"
+}
+resource "dependencytrack_acl_mapping" "test" {
+	project = dependencytrack_project.test.id
+	team = dependencytrack_team.test.id
+}
+`,
+			},
+			// Duplicate reference to ACL.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ACL_Project_236"
+}
+resource "dependencytrack_team" "test" {
+	name = "Test_ACL_Team_236"
+}
+resource "dependencytrack_acl_mapping" "test" {
+	project = dependencytrack_project.test.id
+	team = dependencytrack_team.test.id
+}
+resource "dependencytrack_acl_mapping" "test2" {
+	project = dependencytrack_project.test.id
+	team = dependencytrack_team.test.id
+}
+import {
+	to = dependencytrack_acl_mapping.test2
+	id = dependencytrack_acl_mapping.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_acl_mapping.test", "id",
+						"dependencytrack_acl_mapping.test2", "id",
+					),
+				),
+			},
+			// Remove one, causing other to be removed from state.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ACL_Project_236"
+}
+resource "dependencytrack_team" "test" {
+	name = "Test_ACL_Team_236"
+}
+resource "dependencytrack_acl_mapping" "test2" {
+	project = dependencytrack_project.test.id
+	team = dependencytrack_team.test.id
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_acl_mapping.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/acl_mapping_resource_test.go
+++ b/internal/provider/acl_mapping_resource_test.go
@@ -81,7 +81,7 @@ func TestAccAclMappingResourceRegression236(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create initial ACL
+			// Create initial ACL.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_project" "test" {

--- a/internal/provider/component_property_resource.go
+++ b/internal/provider/component_property_resource.go
@@ -211,9 +211,20 @@ func (r *componentPropertyResource) Read(ctx context.Context, req resource.ReadR
 		return cp.UUID == propertyID
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Missing Component Property when attempting to read. Will be removed from state.", map[string]any{
+				"id":        propertyID.String(),
+				"component": componentID.String(),
+				"group":     state.Group.ValueString(),
+				"name":      state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, Unable to identify Component Property",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 		return
 	}
@@ -339,9 +350,18 @@ func (r *componentPropertyResource) Delete(ctx context.Context, req resource.Del
 
 	err := r.client.Component.DeleteProperty(ctx, componentID, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The component property could not be found (status: 404)" {
+			tflog.Warn(ctx, "Could not delete missing Component Property. Ignoring since in desired state.", map[string]any{
+				"id":        id.String(),
+				"component": componentID.String(),
+				"group":     state.Group.ValueString(),
+				"name":      state.Name.ValueString(),
+			})
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Component Property.",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 		return
 	}

--- a/internal/provider/component_property_resource.go
+++ b/internal/provider/component_property_resource.go
@@ -351,13 +351,14 @@ func (r *componentPropertyResource) Delete(ctx context.Context, req resource.Del
 	err := r.client.Component.DeleteProperty(ctx, componentID, id)
 	if err != nil {
 		err := err.Error()
-		if err == "The component property could not be found (status: 404)" {
+		if err == "The component property could not be found. (status: 404)" {
 			tflog.Warn(ctx, "Could not delete missing Component Property. Ignoring since in desired state.", map[string]any{
 				"id":        id.String(),
 				"component": componentID.String(),
 				"group":     state.Group.ValueString(),
 				"name":      state.Name.ValueString(),
 			})
+			return
 		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Component Property.",
@@ -406,17 +407,18 @@ func (r *componentPropertyResource) ImportState(ctx context.Context, req resourc
 	componentProperties, err := r.client.Component.GetProperties(ctx, componentID)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Within Read, Unable to fetch Component Properties",
+			"Within Import, Unable to fetch Component Properties",
 			"Error from: "+err.Error(),
 		)
 		return
 	}
+
 	componentProperty, err := Find(componentProperties, func(cp dtrack.ComponentProperty) bool {
 		return cp.UUID == propertyID
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Within Read, Unable to identify Component Property",
+			"Within Import, Unable to identify Component Property",
 			"Error from: "+err.Error(),
 		)
 		return

--- a/internal/provider/component_property_resource_test.go
+++ b/internal/provider/component_property_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccComponentPropertyResource(t *testing.T) {
@@ -84,6 +85,105 @@ resource "dependencytrack_component_property" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_component_property.test", "type", "INTEGER"),
 					resource.TestCheckResourceAttr("dependencytrack_component_property.test", "description", "D"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccComponentPropertyResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Component Property.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ComponentProperty_236"
+}
+resource "dependencytrack_component" "test" {
+	project = dependencytrack_project.test.id
+	name = "Test_ComponentProperty_Component_236"
+	version = "v1.0"
+	hashes = {}
+}
+resource "dependencytrack_component_property" "test" {
+	component = dependencytrack_component.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+	description = "D"
+}
+`,
+			},
+			// Duplicate reference to Component Property.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ComponentProperty_236"
+}
+resource "dependencytrack_component" "test" {
+	project = dependencytrack_project.test.id
+	name = "Test_ComponentProperty_Component_236"
+	version = "v1.0"
+	hashes = {}
+}
+resource "dependencytrack_component_property" "test" {
+	component = dependencytrack_component.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+	description = "D"
+}
+resource "dependencytrack_component_property" "test2" {
+	component = dependencytrack_component.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+	description = "D"
+}
+import {
+	to = dependencytrack_component_property.test2
+	id = "${dependencytrack_component.test.id}/${dependencytrack_component_property.test.id}"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_component_property.test", "id",
+						"dependencytrack_component_property.test2", "id",
+					),
+				),
+			},
+			// Remove one, causing other to be removed from state during Read, and handled absence for Delete.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ComponentProperty_236"
+}
+resource "dependencytrack_component" "test" {
+	project = dependencytrack_project.test.id
+	name = "Test_ComponentProperty_Component_236"
+	version = "v1.0"
+	hashes = {}
+}
+resource "dependencytrack_component_property" "test2" {
+	component = dependencytrack_component.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+	description = "D"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_component_property.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/component_resource.go
+++ b/internal/provider/component_resource.go
@@ -283,9 +283,19 @@ func (r *componentResource) Read(ctx context.Context, req resource.ReadRequest, 
 	tflog.Debug(ctx, "Reading Component", state.debug())
 	component, err := r.client.Component.Get(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The component could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Missing Component when reading. Will be removed from state.", map[string]any{
+				"id":      id.String(),
+				"project": state.Project.ValueString(),
+				"name":    state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to get Component",
-			"Error in Component: "+id.String()+", from error: "+err.Error(),
+			"Error in Component: "+id.String()+", from error: "+err,
 		)
 		return
 	}
@@ -349,9 +359,18 @@ func (r *componentResource) Delete(ctx context.Context, req resource.DeleteReque
 	tflog.Debug(ctx, "Deleting Component", state.debug())
 	err := r.client.Component.Delete(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The UUID of the component could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Component. Will be removed from state", map[string]any{
+				"id":      id.String(),
+				"project": state.Project.ValueString(),
+				"name":    state.Name.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete component",
-			"Unexpected error when trying to delete component with id: "+id.String()+", error: "+err.Error(),
+			"Unexpected error when trying to delete component with id: "+id.String()+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/component_resource_test.go
+++ b/internal/provider/component_resource_test.go
@@ -85,7 +85,7 @@ func TestAccComponentResourceRegression236(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create initial Component
+			// Create initial Component.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_project" "test" {
@@ -99,7 +99,7 @@ resource "dependencytrack_component" "test" {
 }
 `,
 			},
-			// Duplicate reference to the component
+			// Duplicate reference to the component.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_project" "test" {
@@ -129,7 +129,7 @@ import {
 					),
 				),
 			},
-			// Delete one
+			// Delete one.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_project" "test" {

--- a/internal/provider/component_resource_test.go
+++ b/internal/provider/component_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccComponentResource(t *testing.T) {
@@ -74,6 +75,79 @@ resource "dependencytrack_component" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_component.test", "hashes.md5", ""),
 					resource.TestCheckResourceAttr("dependencytrack_component.test", "hashes.sha1", ""),
 				),
+			},
+		},
+	})
+}
+
+func TestAccComponentResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Component
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_Component_236"
+}
+resource "dependencytrack_component" "test" {
+	project = dependencytrack_project.test.id
+	name = "Test_Component_236"
+	version = "v1.0"
+	hashes = {}
+}
+`,
+			},
+			// Duplicate reference to the component
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_Component_236"
+}
+resource "dependencytrack_component" "test" {
+	project = dependencytrack_project.test.id
+	name = "Test_Component_236"
+	version = "v1.0"
+	hashes = {}
+}
+resource "dependencytrack_component" "test2" {
+	project = dependencytrack_project.test.id
+	name = "Test_Component_236"
+	version = "v1.0"
+	hashes = {}
+}
+import {
+	to = dependencytrack_component.test2
+	id = dependencytrack_component.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_component.test", "id",
+						"dependencytrack_component.test2", "id",
+					),
+				),
+			},
+			// Delete one
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_Component_236"
+}
+resource "dependencytrack_component" "test2" {
+	project = dependencytrack_project.test.id
+	name = "Test_Component_236"
+	version = "v1.0"
+	hashes = {}
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_component.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/ldap_team_mapping_resource.go
+++ b/internal/provider/ldap_team_mapping_resource.go
@@ -163,6 +163,9 @@ func (r *ldapTeamMappingResource) Read(ctx context.Context, req resource.ReadReq
 	if err != nil {
 		err := err.Error()
 		if err == "did not find item" {
+			// TODO: Since `dependencytrack_ldap_team_mapping` does not implement `Import`:
+			//	unable to create duplicated references in Acceptance Tests.
+			//	So, add Import, adding fields to ImportID as required.
 			tflog.Warn(ctx, "Unable to read missing LDAP Team Mapping. Will be removed from State.", map[string]any{
 				"id":                 state.ID.ValueString(),
 				"team":               state.Team.ValueString(),

--- a/internal/provider/ldap_team_mapping_resource.go
+++ b/internal/provider/ldap_team_mapping_resource.go
@@ -161,11 +161,21 @@ func (r *ldapTeamMappingResource) Read(ctx context.Context, req resource.ReadReq
 	})
 
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing LDAP Team Mapping. Will be removed from State.", map[string]any{
+				"id":                 state.ID.ValueString(),
+				"team":               state.Team.ValueString(),
+				"distinguished_name": state.DistinguishedName.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to locate ldap mapping",
 			fmt.Sprintf(
 				"Error with finding mapping with id: %s, for team: %s, and distinguished name: %s, in original error: %s",
-				id.String(), team.String(), distinguishedName, err.Error(),
+				id.String(), team.String(), distinguishedName, err,
 			),
 		)
 		return

--- a/internal/provider/ldap_user_resource.go
+++ b/internal/provider/ldap_user_resource.go
@@ -181,9 +181,17 @@ func (r *ldapUserResource) Delete(ctx context.Context, req resource.DeleteReques
 	})
 	err := r.client.LDAP.DeleteUser(ctx, user)
 	if err != nil {
+		err := err.Error()
+		if err == "The user could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing LDAP User. Ignoring since in desired state.", map[string]any{
+				"id":       state.ID.ValueString(),
+				"username": state.Username.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete LDAP user",
-			"Error for user: "+user.Username+", from original error: "+err.Error(),
+			"Error for user: "+user.Username+", from original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/ldap_user_resource.go
+++ b/internal/provider/ldap_user_resource.go
@@ -123,9 +123,18 @@ func (r *ldapUserResource) Read(ctx context.Context, req resource.ReadRequest, r
 		},
 	)
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing LDAP User. Will be removed from state.", map[string]any{
+				"id":       state.ID.ValueString(),
+				"username": state.Username.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to read LDAP user",
-			"Error for user: "+username+", in original error: "+err.Error(),
+			"Error for user: "+username+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/ldap_user_resource_test.go
+++ b/internal/provider/ldap_user_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccLDAPUserResource(t *testing.T) {
@@ -39,6 +40,58 @@ resource "dependencytrack_ldap_user" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_ldap_user.test", "id", "Test_Username"),
 					resource.TestCheckResourceAttr("dependencytrack_ldap_user.test", "username", "Test_Username"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccLDAPUserResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial LDAP User.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_ldap_user" "test" {
+	username = "Test_LDAP_User_236"
+}
+`,
+			},
+			// Duplicate reference to LDAP User
+			{
+				Config: providerConfig + `
+resource "dependencytrack_ldap_user" "test" {
+	username = "Test_LDAP_User_236"
+}
+resource "dependencytrack_ldap_user" "test2" {
+	username = "Test_LDAP_User_236"
+}
+import {
+	to = dependencytrack_ldap_user.test2
+	id = dependencytrack_ldap_user.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_ldap_user.test", "id",
+						"dependencytrack_ldap_user.test2", "id",
+					),
+				),
+			},
+			// Delete one
+			{
+				Config: providerConfig + `
+resource "dependencytrack_ldap_user" "test2" {
+	username = "Test_LDAP_User_236"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_ldap_user.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/ldap_user_resource_test.go
+++ b/internal/provider/ldap_user_resource_test.go
@@ -58,7 +58,7 @@ resource "dependencytrack_ldap_user" "test" {
 }
 `,
 			},
-			// Duplicate reference to LDAP User
+			// Duplicate reference to LDAP User.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_ldap_user" "test" {
@@ -79,7 +79,7 @@ import {
 					),
 				),
 			},
-			// Delete one
+			// Delete one.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_ldap_user" "test2" {

--- a/internal/provider/notification_publisher_resource.go
+++ b/internal/provider/notification_publisher_resource.go
@@ -327,7 +327,8 @@ func (r *notificationPublisherResource) Delete(ctx context.Context, req resource
 	err := r.client.Notification.DeletePublisher(ctx, id)
 	if err != nil {
 		err := err.Error()
-		if err == "The UUID of the notification rule could not be found. (status: 404)" { // Mismatch is caused by bug in API returning the incorrect response.
+		// Mismatch of `rule` rather than `publisher` is caused by bug in API returning the incorrect response.
+		if err == "The UUID of the notification rule could not be found. (status: 404)" {
 			tflog.Warn(ctx, "Unable to delete missing Notification Publisher. Ignoring since is desired state.", map[string]any{
 				"id":   state.ID.ValueString(),
 				"name": state.Name.ValueString(),

--- a/internal/provider/notification_publisher_resource.go
+++ b/internal/provider/notification_publisher_resource.go
@@ -326,9 +326,17 @@ func (r *notificationPublisherResource) Delete(ctx context.Context, req resource
 	})
 	err := r.client.Notification.DeletePublisher(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The UUID of the notification rule could not be found. (status: 404)" { // Mismatch is caused by bug in API returning the incorrect response.
+			tflog.Warn(ctx, "Unable to delete missing Notification Publisher. Ignoring since is desired state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Notification Publisher",
-			"Unexpected error when trying to delete Notification Publisher: "+id.String()+", from error: "+err.Error(),
+			"Unexpected error when trying to delete Notification Publisher: "+id.String()+", from error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_publisher_resource.go
+++ b/internal/provider/notification_publisher_resource.go
@@ -183,9 +183,19 @@ func (r *notificationPublisherResource) Read(ctx context.Context, req resource.R
 		return pub.UUID.String() == id.String()
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Notification Publisher. Will be removed from state.", map[string]any{
+				"id":    state.ID.ValueString(),
+				"name":  state.Name.ValueString(),
+				"class": state.PublisherClass.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to read Notification Publisher",
-			"Error with locating ID: "+id.String()+", in original error: "+err.Error(),
+			"Error with locating ID: "+id.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_publisher_resource_test.go
+++ b/internal/provider/notification_publisher_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccNotificationPublisherResource(t *testing.T) {
@@ -57,6 +58,69 @@ resource "dependencytrack_notification_publisher" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_notification_publisher.test", "template_mime_type", "text/plain"),
 					resource.TestCheckResourceAttr("dependencytrack_notification_publisher.test", "default_publisher", "false"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccNotificationPublisherResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Notification Publisher.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Notification_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+	template = "Test"
+}
+`,
+			},
+			// Duplicate reference to Notification Publisher.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Notification_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+	template = "Test"
+}
+resource "dependencytrack_notification_publisher" "test2" {
+	name = "Test_Notification_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+	template = "Test"
+}
+import {
+	to = dependencytrack_notification_publisher.test2
+	id = dependencytrack_notification_publisher.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_notification_publisher.test", "id",
+						"dependencytrack_notification_publisher.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test2" {
+	name = "Test_Notification_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_notification_publisher.test", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/notification_publisher_resource_test.go
+++ b/internal/provider/notification_publisher_resource_test.go
@@ -113,11 +113,12 @@ resource "dependencytrack_notification_publisher" "test2" {
 	name = "Test_Notification_Publisher_236"
 	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
 	template_mime_type = "text/plain"
+	template = "Test"
 }
 `,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("dependencytrack_notification_publisher.test", "Create"),
+						plancheck.ExpectResourceAction("dependencytrack_notification_publisher.test2", "Create"),
 					},
 				},
 				ExpectNonEmptyPlan: true,

--- a/internal/provider/notification_rule_project_resource.go
+++ b/internal/provider/notification_rule_project_resource.go
@@ -178,9 +178,19 @@ func (r *notificationRuleProjectResource) Read(ctx context.Context, req resource
 		return project.UUID == projectID
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Notification Rule Project Mapping. Will be removed from state.", map[string]any{
+				"id":      state.ID.ValueString(),
+				"rule":    state.Rule.ValueString(),
+				"project": state.Project.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to locate Notification Rule Project Mapping when reading",
-			"Error for rule with id: "+ruleID.String()+", and project with id: "+projectID.String()+", in original error: "+err.Error(),
+			"Error for rule with id: "+ruleID.String()+", and project with id: "+projectID.String()+", in original error: "+err,
 		)
 		return
 	}
@@ -281,9 +291,18 @@ func (r *notificationRuleProjectResource) Delete(ctx context.Context, req resour
 	})
 	_, err := r.client.Notification.RemoveProjectFromRule(ctx, ruleID, projectID)
 	if err != nil {
+		err := err.Error()
+		if err == "api error (status: 304)" {
+			tflog.Warn(ctx, "Unable to delete missing Notification Rule Project Mapping. Ignoring since is desired state.", map[string]any{
+				"id":      state.ID.ValueString(),
+				"rule":    state.Rule.ValueString(),
+				"project": state.Project.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Notification Rule Project Mapping",
-			"Error for rule with id: "+ruleID.String()+", and project with id: "+projectID.String()+", in original error: "+err.Error(),
+			"Error for rule with id: "+ruleID.String()+", and project with id: "+projectID.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_rule_project_resource.go
+++ b/internal/provider/notification_rule_project_resource.go
@@ -158,9 +158,19 @@ func (r *notificationRuleProjectResource) Read(ctx context.Context, req resource
 		},
 	)
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Notification Rule for Project. Will be removed from state.", map[string]any{
+				"id":      state.ID.ValueString(),
+				"rule":    state.Rule.ValueString(),
+				"project": state.Project.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to read Notification Rule Project Mapping",
-			"Error for rule with id: "+ruleID.String()+", and project with id: "+projectID.String()+", in original error: "+err.Error(),
+			"Error for rule with id: "+ruleID.String()+", and project with id: "+projectID.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_rule_project_resource_test.go
+++ b/internal/provider/notification_rule_project_resource_test.go
@@ -93,7 +93,7 @@ func TestAccNotificationRuleProjectResourceRegression236(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create initial Notification Rule Project
+			// Create initial Notification Rule Project.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_notification_publisher" "test" {
@@ -115,7 +115,7 @@ resource "dependencytrack_notification_rule_project" "test" {
 }
 `,
 			},
-			// Duplicate reference to Notification Rule Project
+			// Duplicate reference to Notification Rule Project.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_notification_publisher" "test" {

--- a/internal/provider/notification_rule_project_resource_test.go
+++ b/internal/provider/notification_rule_project_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccNotificationRuleProjectResource(t *testing.T) {
@@ -82,6 +83,102 @@ resource "dependencytrack_notification_rule_project" "test" {
 					),
 				),
 				// NOTE: Can check to expect no change to plan.
+			},
+		},
+	})
+}
+
+func TestAccNotificationRuleProjectResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Notification Rule Project
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Project_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Project_Name_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+resource "dependencytrack_project" "test" {
+	name = "Test_Rule_Project_236"
+}
+resource "dependencytrack_notification_rule_project" "test" {
+	rule = dependencytrack_notification_rule.test.id
+	project = dependencytrack_project.test.id
+}
+`,
+			},
+			// Duplicate reference to Notification Rule Project
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Project_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Project_Name_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+resource "dependencytrack_project" "test" {
+	name = "Test_Rule_Project_236"
+}
+resource "dependencytrack_notification_rule_project" "test" {
+	rule = dependencytrack_notification_rule.test.id
+	project = dependencytrack_project.test.id
+}
+resource "dependencytrack_notification_rule_project" "test2" {
+	rule = dependencytrack_notification_rule.test.id
+	project = dependencytrack_project.test.id
+}
+import {
+	to = dependencytrack_notification_rule_project.test2
+	id = dependencytrack_notification_rule_project.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_notification_rule_project.test", "id",
+						"dependencytrack_notification_rule_project.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Project_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Project_Name_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+resource "dependencytrack_project" "test" {
+	name = "Test_Rule_Project_236"
+}
+resource "dependencytrack_notification_rule_project" "test2" {
+	rule = dependencytrack_notification_rule.test.id
+	project = dependencytrack_project.test.id
+}
+
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_notification_rule_project.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/notification_rule_resource.go
+++ b/internal/provider/notification_rule_resource.go
@@ -372,9 +372,19 @@ func (r *notificationRuleResource) Read(ctx context.Context, req resource.ReadRe
 		},
 	)
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Notification Rule. Will be removed from state.", map[string]any{
+				"id":        state.ID.ValueString(),
+				"name":      state.Name.ValueString(),
+				"publisher": state.PublisherID.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to read Notification Rule",
-			"Error with finding notification rule with ID: "+id.String()+", in original error: "+err.Error(),
+			"Error with finding notification rule with ID: "+id.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_rule_resource.go
+++ b/internal/provider/notification_rule_resource.go
@@ -633,9 +633,18 @@ func (r *notificationRuleResource) Delete(ctx context.Context, req resource.Dele
 		TriggerType: dtrack.NotificationRuleTriggerTypeEvent,
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "The UUID of the notification rule could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Notification Rule. Ignoring since is desired state.", map[string]any{
+				"id":        state.ID.ValueString(),
+				"name":      state.Name.ValueString(),
+				"publisher": state.PublisherID.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Notification Rule",
-			"Error in id: "+id.String()+", in original error: "+err.Error(),
+			"Error in id: "+id.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_rule_resource_test.go
+++ b/internal/provider/notification_rule_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccNotificationRuleEventResource(t *testing.T) {
@@ -167,6 +168,81 @@ resource "dependencytrack_notification_rule" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_notification_rule.test", "schedule_cron", "0 0 * * 1"),
 					resource.TestCheckResourceAttr("dependencytrack_notification_rule.test", "schedule_skip_unchanged", "true"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccNotificationRuleResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Notification Rule
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Publisher_Event_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Name_Event_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+`,
+			},
+			// Duplicate reference to Notification Rule
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Publisher_Event_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Name_Event_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+resource "dependencytrack_notification_rule" "test2" {
+	name = "Test_Rule_Name_Event_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+import {
+	to = dependencytrack_notification_rule.test2
+	id = dependencytrack_notification_rule.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_notification_rule.test", "id",
+						"dependencytrack_notification_rule.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Publisher_Event_236"
+	publisher_class = "org.dependencytrack.notification.publisher.ConsolePublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test2" {
+	name = "Test_Rule_Name_Event_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_notification_rule.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/notification_rule_resource_test.go
+++ b/internal/provider/notification_rule_resource_test.go
@@ -178,7 +178,7 @@ func TestAccNotificationRuleResourceRegression236(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create initial Notification Rule
+			// Create initial Notification Rule.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_notification_publisher" "test" {
@@ -193,7 +193,7 @@ resource "dependencytrack_notification_rule" "test" {
 }
 `,
 			},
-			// Duplicate reference to Notification Rule
+			// Duplicate reference to Notification Rule.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_notification_publisher" "test" {

--- a/internal/provider/notification_rule_team_resource.go
+++ b/internal/provider/notification_rule_team_resource.go
@@ -178,9 +178,19 @@ func (r *notificationRuleTeamResource) Read(ctx context.Context, req resource.Re
 		return team.UUID == teamID
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Notification Rule Team Mapping. Will be removed from state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"rule": state.Rule.ValueString(),
+				"team": state.Team.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to locate Notification Rule Team Mapping when reading",
-			"Error for rule with id: "+ruleID.String()+", and team with id: "+teamID.String()+", in original error: "+err.Error(),
+			"Error for rule with id: "+ruleID.String()+", and team with id: "+teamID.String()+", in original error: "+err,
 		)
 		return
 	}
@@ -281,9 +291,18 @@ func (r *notificationRuleTeamResource) Delete(ctx context.Context, req resource.
 	})
 	_, err := r.client.Notification.RemoveTeamFromRule(ctx, ruleID, teamID)
 	if err != nil {
+		err := err.Error()
+		if err == "api error (status: 304)" {
+			tflog.Warn(ctx, "Unable to delete missing Notification Rule Team Mapping. Ignoring since is desired state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"rule": state.Rule.ValueString(),
+				"team": state.Team.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Notification Rule Team Mapping",
-			"Error for rule with id: "+ruleID.String()+", and team with id: "+teamID.String()+", in original error: "+err.Error(),
+			"Error for rule with id: "+ruleID.String()+", and team with id: "+teamID.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_rule_team_resource.go
+++ b/internal/provider/notification_rule_team_resource.go
@@ -158,9 +158,19 @@ func (r *notificationRuleTeamResource) Read(ctx context.Context, req resource.Re
 		},
 	)
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Notification Rule for Team. Will be removed from state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"rule": state.Rule.ValueString(),
+				"team": state.Team.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to read Notification Rule Team Mapping",
-			"Error for rule with id: "+ruleID.String()+", and team with id: "+teamID.String()+", in original error: "+err.Error(),
+			"Error for rule with id: "+ruleID.String()+", and team with id: "+teamID.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/notification_rule_team_resource_test.go
+++ b/internal/provider/notification_rule_team_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccNotificationRuleTeamResource(t *testing.T) {
@@ -82,6 +83,101 @@ resource "dependencytrack_notification_rule_team" "test" {
 					),
 				),
 				// NOTE: Can check to expect no change to plan.
+			},
+		},
+	})
+}
+
+func TestAccNotificationRuleTeamResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Notification Rule Team.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Team_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.SendMailPublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Team_Name_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+resource "dependencytrack_team" "test" {
+	name = "Test_Rule_Team_236"
+}
+resource "dependencytrack_notification_rule_team" "test" {
+	rule = dependencytrack_notification_rule.test.id
+	team = dependencytrack_team.test.id
+}
+`,
+			},
+			// Duplicate reference to Notification Rule Team.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Team_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.SendMailPublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Team_Name_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+resource "dependencytrack_team" "test" {
+	name = "Test_Rule_Team_236"
+}
+resource "dependencytrack_notification_rule_team" "test" {
+	rule = dependencytrack_notification_rule.test.id
+	team = dependencytrack_team.test.id
+}
+resource "dependencytrack_notification_rule_team" "test2" {
+	rule = dependencytrack_notification_rule.test.id
+	team = dependencytrack_team.test.id
+}
+import {
+	to = dependencytrack_notification_rule_team.test2
+	id = dependencytrack_notification_rule_team.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_notification_rule_team.test", "id",
+						"dependencytrack_notification_rule_team.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_notification_publisher" "test" {
+	name = "Test_Rule_Team_Publisher_236"
+	publisher_class = "org.dependencytrack.notification.publisher.SendMailPublisher"
+	template_mime_type = "text/plain"
+}
+resource "dependencytrack_notification_rule" "test" {
+	name = "Test_Rule_Team_Name_236"
+	trigger_type = "EVENT"
+	publisher_id = dependencytrack_notification_publisher.test.id
+}
+resource "dependencytrack_team" "test" {
+	name = "Test_Rule_Team_236"
+}
+resource "dependencytrack_notification_rule_team" "test2" {
+	rule = dependencytrack_notification_rule.test.id
+	team = dependencytrack_team.test.id
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_notification_rule_team.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/oidc_group_mapping_resource.go
+++ b/internal/provider/oidc_group_mapping_resource.go
@@ -266,9 +266,18 @@ func (r *oidcGroupMappingResource) Delete(ctx context.Context, req resource.Dele
 	})
 	err := r.client.OIDC.RemoveTeamMapping(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The UUID of the mapping could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete OIDC Group Mapping. Ignoring since in desired state.", map[string]any{
+				"id":    state.ID.ValueString(),
+				"team":  state.Team.ValueString(),
+				"group": state.Group.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete group mapping",
-			"Unexpected error when trying to delete oidc group mapping with id: "+id.String()+", error: "+err.Error(),
+			"Unexpected error when trying to delete oidc group mapping with id: "+id.String()+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/oidc_group_mapping_resource.go
+++ b/internal/provider/oidc_group_mapping_resource.go
@@ -150,11 +150,21 @@ func (r *oidcGroupMappingResource) Read(ctx context.Context, req resource.ReadRe
 		return r.client.Team.GetAll(ctx, po)
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing OIDC Group Mapping. Will be removed from state.", map[string]any{
+				"id":    state.ID.ValueString(),
+				"team":  state.Team.ValueString(),
+				"group": state.Group.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to get group team mapping within Read",
 			fmt.Sprintf(
 				"Error with reading OIDC Group Mapping with id: %s, for team: %s, and group: %s, in original errr: %s",
-				id.String(), state.Team.ValueString(), state.Group.ValueString(), err.Error(),
+				id.String(), state.Team.ValueString(), state.Group.ValueString(), err,
 			),
 		)
 		return

--- a/internal/provider/oidc_group_mapping_resource_test.go
+++ b/internal/provider/oidc_group_mapping_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccOidcGroupMappingResource(t *testing.T) {
@@ -70,6 +71,80 @@ resource "dependencytrack_oidc_group_mapping" "test" {
 						"dependencytrack_oidc_group.test2", "id",
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestAccOIDCGroupMappingResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial OIDC Group Mapping
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_OIDCGroupMapping_236"
+}
+resource "dependencytrack_oidc_group" "test" {
+	name = "Test_OIDCGroupMapping_236"
+}
+resource "dependencytrack_oidc_group_mapping" "test" {
+	team = dependencytrack_team.test.id
+	group = dependencytrack_oidc_group.test.id
+}
+`,
+			},
+			// Duplicate reference to OIDC Group Mapping
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_OIDCGroupMapping_236"
+}
+resource "dependencytrack_oidc_group" "test" {
+	name = "Test_OIDCGroupMapping_236"
+}
+resource "dependencytrack_oidc_group_mapping" "test" {
+	team = dependencytrack_team.test.id
+	group = dependencytrack_oidc_group.test.id
+}
+resource "dependencytrack_oidc_group_mapping" "test2" {
+	team = dependencytrack_team.test.id
+	group = dependencytrack_oidc_group.test.id
+}
+import {
+	to = dependencytrack_oidc_group_mapping.test2
+	id = dependencytrack_oidc_group_mapping.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_oidc_group_mapping.test", "id",
+						"dependencytrack_oidc_group_mapping.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_OIDCGroupMapping_236"
+}
+resource "dependencytrack_oidc_group" "test" {
+	name = "Test_OIDCGroupMapping_236"
+}
+resource "dependencytrack_oidc_group_mapping" "test2" {
+	team = dependencytrack_team.test.id
+	group = dependencytrack_oidc_group.test.id
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_oidc_group_mapping.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/oidc_group_mapping_resource_test.go
+++ b/internal/provider/oidc_group_mapping_resource_test.go
@@ -81,7 +81,7 @@ func TestAccOIDCGroupMappingResourceRegression236(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create initial OIDC Group Mapping
+			// Create initial OIDC Group Mapping.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_team" "test" {
@@ -96,7 +96,7 @@ resource "dependencytrack_oidc_group_mapping" "test" {
 }
 `,
 			},
-			// Duplicate reference to OIDC Group Mapping
+			// Duplicate reference to OIDC Group Mapping.
 			{
 				Config: providerConfig + `
 resource "dependencytrack_team" "test" {

--- a/internal/provider/oidc_group_resource.go
+++ b/internal/provider/oidc_group_resource.go
@@ -123,9 +123,18 @@ func (r *oidcGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 	oidcGroup, err := Find(oidcGroups, func(group dtrack.OIDCGroup) bool { return group.UUID == id })
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing OIDC Group. Will be removed from state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to locate updated oidc group",
-			"Error with locating oidc group: "+id.String()+", in original error: "+err.Error(),
+			"Error with locating oidc group: "+id.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/oidc_group_resource.go
+++ b/internal/provider/oidc_group_resource.go
@@ -231,9 +231,17 @@ func (r *oidcGroupResource) Delete(ctx context.Context, req resource.DeleteReque
 	})
 	err := r.client.OIDC.DeleteGroup(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "An OpenID Connect group with the specified UUID could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing OIDC Group. Ignoring since in desired state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete oidc group",
-			"Unexpected error when trying to delete oidc group: "+id.String()+", error: "+err.Error(),
+			"Unexpected error when trying to delete oidc group: "+id.String()+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/oidc_group_resource_test.go
+++ b/internal/provider/oidc_group_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccOidcGroupResource(t *testing.T) {
@@ -39,6 +40,58 @@ resource "dependencytrack_oidc_group" "test" {
 					resource.TestCheckResourceAttrSet("dependencytrack_oidc_group.test", "id"),
 					resource.TestCheckResourceAttr("dependencytrack_oidc_group.test", "name", "Test_Group_2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccOIDCGroupResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Group.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_oidc_group" "test" {
+	name = "Test_OIDC_Group_236"
+}
+`,
+			},
+			// Duplicate reference to the Group.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_oidc_group" "test" {
+	name = "Test_OIDC_Group_236"
+}
+resource "dependencytrack_oidc_group" "test2" {
+	name = "Test_OIDC_Group_236"
+}
+import {
+	to = dependencytrack_oidc_group.test2
+	id = dependencytrack_oidc_group.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_oidc_group.test", "id",
+						"dependencytrack_oidc_group.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_oidc_group" "test2" {
+	name = "Test_OIDC_Group_236"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_oidc_group.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/oidc_user_resource.go
+++ b/internal/provider/oidc_user_resource.go
@@ -124,9 +124,18 @@ func (r *oidcUserResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 	user, err := Find(users.Items, func(user dtrack.OIDCUser) bool { return user.Username == username })
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing OIDC User. Will be removed from state.", map[string]any{
+				"id":       state.ID.ValueString(),
+				"username": state.Username.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to locate OIDC user",
-			"Error for user: "+username+", in original error: "+err.Error(),
+			"Error for user: "+username+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/oidc_user_resource.go
+++ b/internal/provider/oidc_user_resource.go
@@ -181,9 +181,17 @@ func (r *oidcUserResource) Delete(ctx context.Context, req resource.DeleteReques
 	})
 	err := r.client.OIDC.DeleteUser(ctx, user)
 	if err != nil {
+		err := err.Error()
+		if err == "The user could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing OIDC User. Ignoring since in desired state. (status: 404)", map[string]any{
+				"id":       state.ID.ValueString(),
+				"username": state.Username.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete OIDC user",
-			"Error for user: "+user.Username+", from original error: "+err.Error(),
+			"Error for user: "+user.Username+", from original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/oidc_user_resource_test.go
+++ b/internal/provider/oidc_user_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccOIDCUserResource(t *testing.T) {
@@ -39,6 +40,58 @@ resource "dependencytrack_oidc_user" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_oidc_user.test", "id", "Test_Username"),
 					resource.TestCheckResourceAttr("dependencytrack_oidc_user.test", "username", "Test_Username"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccOIDCUserResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial OIDC User.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_oidc_user" "test" {
+	username = "Test_OIDCUser_236"
+}
+`,
+			},
+			// Duplicate reference to OIDC User.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_oidc_user" "test" {
+	username = "Test_OIDCUser_236"
+}
+resource "dependencytrack_oidc_user" "test2" {
+	username = "Test_OIDCUser_236"
+}
+import {
+	to = dependencytrack_oidc_user.test2
+	id = dependencytrack_oidc_user.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_oidc_user.test", "id",
+						"dependencytrack_oidc_user.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_oidc_user" "test2" {
+	username = "Test_OIDCUser_236"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_oidc_user.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/policy_condition_resource.go
+++ b/internal/provider/policy_condition_resource.go
@@ -161,9 +161,19 @@ func (r *policyConditionResource) Read(ctx context.Context, req resource.ReadReq
 		return r.client.Policy.GetAll(ctx, po)
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Policy Condition. Will be removed from state.", map[string]any{
+				"id":      state.ID.ValueString(),
+				"policy":  state.PolicyID.ValueString(),
+				"subject": state.Subject.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to identify policy condition",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 		return
 	}

--- a/internal/provider/policy_condition_resource.go
+++ b/internal/provider/policy_condition_resource.go
@@ -297,11 +297,18 @@ func (r *policyConditionResource) Delete(ctx context.Context, req resource.Delet
 		"value":    state.Value.ValueString(),
 	})
 	err := r.client.PolicyCondition.Delete(ctx, id)
-
 	if err != nil {
+		err := err.Error()
+		if err == "The UUID of the policy condition could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Policy Condition. Ignoring since in desired state.", map[string]any{
+				"id":     state.ID.ValueString(),
+				"policy": state.PolicyID.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete policy condition",
-			"Unexpected error when trying to delete policy condition: "+id.String()+", error: "+err.Error(),
+			"Unexpected error when trying to delete policy condition: "+id.String()+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/policy_condition_resource_test.go
+++ b/internal/provider/policy_condition_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccPolicyConditionResource(t *testing.T) {
@@ -67,6 +68,85 @@ resource "dependencytrack_policy_condition" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_policy_condition.test", "operator", "NUMERIC_GREATER_THAN"),
 					resource.TestCheckResourceAttr("dependencytrack_policy_condition.test", "value", "P2Y"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccPolicyConditionResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Policy Condition.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_policy" "test" {
+	name = "Test_PolicyCondition_236"
+	operator = "ANY"
+	violation = "FAIL"
+}
+resource "dependencytrack_policy_condition" "test" {
+	policy = dependencytrack_policy.test.id
+	subject = "AGE"
+	operator = "NUMERIC_GREATER_THAN"
+	value = "P2Y"
+}
+`,
+			},
+			// Duplicate reference to Policy Condition.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_policy" "test" {
+	name = "Test_PolicyCondition_236"
+	operator = "ANY"
+	violation = "FAIL"
+}
+resource "dependencytrack_policy_condition" "test" {
+	policy = dependencytrack_policy.test.id
+	subject = "AGE"
+	operator = "NUMERIC_GREATER_THAN"
+	value = "P2Y"
+}
+resource "dependencytrack_policy_condition" "test2" {
+	policy = dependencytrack_policy.test.id
+	subject = "AGE"
+	operator = "NUMERIC_GREATER_THAN"
+	value = "P2Y"
+}
+import {
+	to = dependencytrack_policy_condition.test2
+	id = dependencytrack_policy_condition.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_policy_condition.test", "id",
+						"dependencytrack_policy_condition.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_policy" "test" {
+	name = "Test_PolicyCondition_236"
+	operator = "ANY"
+	violation = "FAIL"
+}
+resource "dependencytrack_policy_condition" "test2" {
+	policy = dependencytrack_policy.test.id
+	subject = "AGE"
+	operator = "NUMERIC_GREATER_THAN"
+	value = "P2Y"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_policy_condition.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/policy_project_resource.go
+++ b/internal/provider/policy_project_resource.go
@@ -250,9 +250,17 @@ func (r *policyProjectResource) Delete(ctx context.Context, req resource.DeleteR
 	})
 	_, err := r.client.Policy.DeleteProject(ctx, policyID, projectID)
 	if err != nil {
+		err := err.Error()
+		if err == "api error (status: 304)" { // TODO: Not covered by test, due to resource no implementing `Import`. Same for check within `Read`.
+			tflog.Warn(ctx, "Unable to delete missing Project Policy Mapping. Ignoring, since is desired state.", map[string]any{
+				"policy":  state.PolicyID.ValueString(),
+				"project": state.ProjectID.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete project-policy mapping",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 	}
 	tflog.Debug(ctx, "Deleted Policy Project Mapping", map[string]any{

--- a/internal/provider/policy_project_resource.go
+++ b/internal/provider/policy_project_resource.go
@@ -147,9 +147,18 @@ func (r *policyProjectResource) Read(ctx context.Context, req resource.ReadReque
 		return project.UUID == projectID
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Policy Project Mapping. Will be removed from state.", map[string]any{
+				"policy":  state.PolicyID.ValueString(),
+				"project": state.ProjectID.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to locate project-policy mapping",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 		return
 	}

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -259,9 +259,17 @@ func (r *policyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	})
 	err := r.client.Policy.Delete(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The UUID of the policy could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Policy. Ignoring since is desired state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete policy",
-			"Unexpected error when trying to delete policy: "+id.String()+", from error: "+err.Error(),
+			"Unexpected error when trying to delete policy: "+id.String()+", from error: "+err,
 		)
 		return
 	}

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -139,9 +139,18 @@ func (r *policyResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	policy, err := r.client.Policy.Get(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The policy could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to read missing Policy. Will be removed from state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to get updated policy",
-			"Error with reading policy: "+id.String()+", from: "+err.Error(),
+			"Error with reading policy: "+id.String()+", from: "+err,
 		)
 		return
 	}

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccPolicyResource(t *testing.T) {
@@ -47,6 +48,66 @@ resource "dependencytrack_policy" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_policy.test", "operator", "ANY"),
 					resource.TestCheckResourceAttr("dependencytrack_policy.test", "violation", "FAIL"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccPolicyResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Policy.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_policy" "test" {
+	name = "Test_Policy_236"
+	operator = "ANY"
+	violation = "FAIL"
+}
+`,
+			},
+			// Duplicate reference to Policy.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_policy" "test" {
+	name = "Test_Policy_236"
+	operator = "ANY"
+	violation = "FAIL"
+}
+resource "dependencytrack_policy" "test2" {
+	name = "Test_Policy_236"
+	operator = "ANY"
+	violation = "FAIL"
+}
+import {
+	to = dependencytrack_policy.test2
+	id = dependencytrack_policy.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_policy.test", "id",
+						"dependencytrack_policy.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_policy" "test2" {
+	name = "Test_Policy_236"
+	operator = "ANY"
+	violation = "FAIL"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_policy.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/policy_tag_resource.go
+++ b/internal/provider/policy_tag_resource.go
@@ -227,9 +227,17 @@ func (r *policyTagResource) Delete(ctx context.Context, req resource.DeleteReque
 	})
 	_, err := r.client.Policy.DeleteTag(ctx, policyID, tagName)
 	if err != nil {
+		err := err.Error()
+		if err == "api error (status: 304)" {
+			tflog.Warn(ctx, "Unable to delete missing Policy Tag. Ignoring since is desired state.", map[string]any{
+				"policy": state.PolicyID.ValueString(),
+				"tag":    state.Tag.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Policy Tag Mapping",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 	}
 	tflog.Debug(ctx, "Deleted Policy Tag Mapping", map[string]any{

--- a/internal/provider/policy_tag_resource.go
+++ b/internal/provider/policy_tag_resource.go
@@ -137,9 +137,18 @@ func (r *policyTagResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return tag.Name == tagName
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Policy Tag. Will be removed from state.", map[string]any{
+				"policy": state.PolicyID.ValueString(),
+				"tag":    state.Tag.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to locate Policy Tag Mapping",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 		return
 	}

--- a/internal/provider/project_property_resource.go
+++ b/internal/provider/project_property_resource.go
@@ -326,9 +326,16 @@ func (r *projectPropertyResource) Delete(ctx context.Context, req resource.Delet
 	})
 	err := r.client.ProjectProperty.Delete(ctx, project, groupName, propertyName)
 	if err != nil {
+		err := err.Error()
+		if err == "The project property could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Project Property. Ignoring, since is desired state.", map[string]any{
+				"id": state.ID.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete project property.",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 		return
 	}

--- a/internal/provider/project_property_resource.go
+++ b/internal/provider/project_property_resource.go
@@ -329,7 +329,10 @@ func (r *projectPropertyResource) Delete(ctx context.Context, req resource.Delet
 		err := err.Error()
 		if err == "The project property could not be found. (status: 404)" {
 			tflog.Warn(ctx, "Unable to delete missing Project Property. Ignoring, since is desired state.", map[string]any{
-				"id": state.ID.ValueString(),
+				"project": state.Project.ValueString(),
+				"group":   state.Group.ValueString(),
+				"name":    state.Name.ValueString(),
+				"type":    state.Type.ValueString(),
 			})
 			return
 		}

--- a/internal/provider/project_property_resource.go
+++ b/internal/provider/project_property_resource.go
@@ -324,7 +324,6 @@ func (r *projectPropertyResource) Delete(ctx context.Context, req resource.Delet
 		"type":        state.Type.ValueString(),
 		"description": state.Description.ValueString(),
 	})
-	// NOTE: Has a patch applied in `http_client.go`.
 	err := r.client.ProjectProperty.Delete(ctx, project, groupName, propertyName)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/project_property_resource.go
+++ b/internal/provider/project_property_resource.go
@@ -187,19 +187,24 @@ func (r *projectPropertyResource) Read(ctx context.Context, req resource.ReadReq
 			return r.client.ProjectProperty.GetAll(ctx, project, po)
 		},
 		func(property dtrack.ProjectProperty) bool {
-			if property.Group != state.Group.ValueString() {
-				return false
-			}
-			if property.Name != state.Name.ValueString() {
-				return false
-			}
-			return true
+			return property.Group == state.Group.ValueString() && property.Name == state.Name.ValueString()
 		},
 	)
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Project Property. Will be removed from state.", map[string]any{
+				"project": state.Project.ValueString(),
+				"group":   state.Group.ValueString(),
+				"name":    state.Name.ValueString(),
+				"type":    state.Type.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to locate Project Property.",
-			"Error from: "+err.Error(),
+			"Error from: "+err,
 		)
 	}
 	propertyState := projectPropertyResourceModel{

--- a/internal/provider/project_property_resource_test.go
+++ b/internal/provider/project_property_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccProjectPropertyResource(t *testing.T) {
@@ -119,6 +120,83 @@ resource "dependencytrack_project_property" "testencrypted" {
 					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "type", "ENCRYPTEDSTRING"),
 					resource.TestCheckResourceAttr("dependencytrack_project_property.testencrypted", "description", "D-Enc"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccProjectPropertyResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Project Property.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ProjectProperty_236"
+}
+resource "dependencytrack_project_property" "test" {
+	project = dependencytrack_project.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+}
+`,
+			},
+			// Duplicate reference to Project Property.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ProjectProperty_236"
+}
+resource "dependencytrack_project_property" "test" {
+	project = dependencytrack_project.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+}
+resource "dependencytrack_project_property" "test2" {
+	project = dependencytrack_project.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+}
+import {
+	to = dependencytrack_project_property.test2
+	id = dependencytrack_project_property.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_project_property.test", "id",
+						"dependencytrack_project_property.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_ProjectProperty_236"
+}
+resource "dependencytrack_project_property" "test2" {
+	project = dependencytrack_project.test.id
+	group = "A"
+	name = "B"
+	value = "2"
+	type = "INTEGER"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_project_property.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -673,8 +673,9 @@ func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest
 	err := r.client.Project.Delete(ctx, id)
 	if err != nil {
 		err := err.Error()
-		if r.semver.Major == 4 && err == "The UUID of the project could not be found. (status: 404)" ||
-			r.semver.Major == 5 && err == "{\"status\":404,\"title\":\"Resource does not exist\",\"detail\":\"Project could not be found\"} (status: 404)" {
+		if (r.semver.Major == 4 || (r.semver.Major == 5 && r.semver.Minor < 1)) && err == "The UUID of the project could not be found. (status: 404)" ||
+			r.semver.Major == 5 && r.semver.Minor >= 1 &&
+				err == "{\"status\":404,\"title\":\"Resource does not exist\",\"detail\":\"Project could not be found\"} (status: 404)" {
 			tflog.Warn(ctx, "Unable to delete missing Property. Ignoring since is desired state.", map[string]any{
 				"id":      state.ID.ValueString(),
 				"name":    state.Name.ValueString(),

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -353,9 +353,20 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	})
 	project, err := r.client.Project.Get(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The project could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to read missing Project. Will be removed from state.", map[string]any{
+				"id":      state.ID.ValueString(),
+				"name":    state.Name.ValueString(),
+				"version": state.Version.ValueString(),
+				"parent":  state.Parent.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to get updated project",
-			"Error with reading project: "+id.String()+", in original error: "+err.Error(),
+			"Error with reading project: "+id.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -672,9 +672,20 @@ func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest
 	})
 	err := r.client.Project.Delete(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if r.semver.Major == 4 && err == "The UUID of the project could not be found. (status: 404)" ||
+			r.semver.Major == 5 && err == "{\"status\":404,\"title\":\"Resource does not exist\",\"detail\":\"Project could not be found\"} (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Property. Ignoring since is desired state.", map[string]any{
+				"id":      state.ID.ValueString(),
+				"name":    state.Name.ValueString(),
+				"version": state.Version,
+			})
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to delete project",
-			"Unexpected error when trying to delete project: "+id.String()+", error: "+err.Error(),
+			"Unexpected error when trying to delete project: "+id.String()+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -673,10 +673,13 @@ func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest
 	err := r.client.Project.Delete(ctx, id)
 	if err != nil {
 		err := err.Error()
-		if (r.semver.Major == 4 || (r.semver.Major == 5 && r.semver.Minor < 1)) && err == "The UUID of the project could not be found. (status: 404)" ||
-			r.semver.Major == 5 && r.semver.Minor >= 1 &&
-				err == "{\"status\":404,\"title\":\"Resource does not exist\",\"detail\":\"Project could not be found\"} (status: 404)" {
-			tflog.Warn(ctx, "Unable to delete missing Property. Ignoring since is desired state.", map[string]any{
+		missing := r.semver.Major == 4 && err == "The UUID of the project could not be found. (status: 404)"
+		missing = missing || (r.semver.Major == 5 && r.semver.Minor == 0 && err == "The UUID of the project could not be found. (status: 404)")
+		missing = missing || (r.semver.Major == 5 && r.semver.Minor >= 1 &&
+			err == "{\"status\":404,\"title\":\"Resource does not exist\",\"detail\":\"Project could not be found\"} (status: 404)")
+
+		if missing {
+			tflog.Warn(ctx, "Unable to delete missing Project. Ignoring since is desired state.", map[string]any{
 				"id":      state.ID.ValueString(),
 				"name":    state.Name.ValueString(),
 				"version": state.Version,

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccProjectResource(t *testing.T) {
@@ -497,6 +498,59 @@ resource "dependencytrack_project" "example" {
 					resource.TestCheckResourceAttr("dependencytrack_project.example", "tags.0", "collection-example"),
 					resource.TestCheckResourceAttr("dependencytrack_project.example", "tags.1", "environment-test"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccProjectResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Project.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_Project_236"
+}
+`,
+			},
+			// Duplicate reference to Project.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test" {
+	name = "Test_Project_236"
+}
+resource "dependencytrack_project" "test2" {
+	name = "Test_Project_236"
+}
+import {
+	to = dependencytrack_project.test2
+	id = dependencytrack_project.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_project.test", "id",
+						"dependencytrack_project.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_project" "test2" {
+	name = "Test_Project_236"
+}
+`,
+
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_project.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -60,7 +60,7 @@ var (
 			}`
 		}
 		return `provider "dependencytrack" {
-			host = "http://localhost:8081"
+			host = "http://localhost:9081"
 			key = "OS_ENV"
 		}`
 	}()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -60,7 +60,7 @@ var (
 			}`
 		}
 		return `provider "dependencytrack" {
-			host = "http://localhost:9081"
+			host = "http://localhost:8081"
 			key = "OS_ENV"
 		}`
 	}()

--- a/internal/provider/repository_resource.go
+++ b/internal/provider/repository_resource.go
@@ -355,9 +355,18 @@ func (r *repositoryResource) Delete(ctx context.Context, req resource.DeleteRequ
 	})
 	err := r.client.Repository.Delete(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "The UUID of the repository could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Repository. Ignoring since is desired state.", map[string]any{
+				"id":         state.ID.ValueString(),
+				"type":       state.Type.ValueString(),
+				"identifier": state.Identifier.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete repository",
-			"Unexpected error when trying to delete repository: "+id.String()+", error: "+err.Error(),
+			"Unexpected error when trying to delete repository: "+id.String()+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/repository_resource.go
+++ b/internal/provider/repository_resource.go
@@ -190,8 +190,9 @@ func (r *repositoryResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 	tflog.Debug(ctx, "Reading Repository", map[string]any{
-		"id":   id.String(),
-		"type": repoType,
+		"id":         id.String(),
+		"type":       repoType,
+		"identifier": state.Identifier.ValueString(),
 	})
 
 	repository, err := FindPaged(
@@ -204,9 +205,19 @@ func (r *repositoryResource) Read(ctx context.Context, req resource.ReadRequest,
 	)
 
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Repository. Will be removed from state.", map[string]any{
+				"id":         state.ID.ValueString(),
+				"type":       state.Type.ValueString(),
+				"identifier": state.Identifier.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to get updated repository",
-			"Error with reading repository: "+id.String()+", in original error: "+err.Error(),
+			"Error with reading repository: "+id.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/repository_resource_test.go
+++ b/internal/provider/repository_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccRepositoryResource(t *testing.T) {
@@ -72,6 +73,82 @@ resource "dependencytrack_repository" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_repository.test", "username", "Test_Username"),
 					resource.TestCheckResourceAttr("dependencytrack_repository.test", "password", "Test_Password_With_Change"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccRepositoryResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Repository.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_repository" "test" {
+	type = "GITHUB"
+	identifier = "Test_Repository_236"
+	url = "https://localhost"
+	internal = false
+	enabled = true
+	username = ""
+	password = ""
+}
+`,
+			},
+			// Duplicate reference to the Repository.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_repository" "test" {
+	type = "GITHUB"
+	identifier = "Test_Repository_236"
+	url = "https://localhost"
+	internal = false
+	enabled = true
+	username = ""
+	password = ""
+}
+resource "dependencytrack_repository" "test2" {
+	type = "GITHUB"
+	identifier = "Test_Repository_236"
+	url = "https://localhost"
+	internal = false
+	enabled = true
+	username = ""
+	password = ""
+}
+import {
+	to = dependencytrack_repository.test2
+	id = dependencytrack_repository.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_repository.test", "id",
+						"dependencytrack_repository.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_repository" "test2" {
+	type = "GITHUB"
+	identifier = "Test_Repository_236"
+	url = "https://localhost"
+	internal = false
+	enabled = true
+	username = ""
+	password = ""
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_repository.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/tag_resource.go
+++ b/internal/provider/tag_resource.go
@@ -120,9 +120,17 @@ func (r *tagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return tag.Name == tagID
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Tag. Will be removed from state.", map[string]any{
+				"id": state.ID.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to get updated tag",
-			"Error with reading tag: "+tagID+", from: "+err.Error(),
+			"Error with reading tag: "+tagID+", from: "+err,
 		)
 		return
 	}

--- a/internal/provider/tag_resource.go
+++ b/internal/provider/tag_resource.go
@@ -206,8 +206,7 @@ func (r *tagResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	err := r.client.Tag.Delete(ctx, []string{tagID})
 	if err != nil {
 		err := err.Error()
-		// TODO: Check what happens in API v4.
-		if r.semver.Major == 5 && err == fmt.Sprintf(
+		if err == fmt.Sprintf(
 			"{\"status\":400,\"title\":\"Tag operation failed\",\"detail\":\"The tag(s) %s could not be deleted\",\"errors\":{\"%s\":\"Tag does not exist\"}} (status: 400)",
 			tagID, tagID,
 		) {

--- a/internal/provider/tag_resource.go
+++ b/internal/provider/tag_resource.go
@@ -205,9 +205,20 @@ func (r *tagResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	})
 	err := r.client.Tag.Delete(ctx, []string{tagID})
 	if err != nil {
+		err := err.Error()
+		// TODO: Check what happens in API v4.
+		if r.semver.Major == 5 && err == fmt.Sprintf(
+			"{\"status\":400,\"title\":\"Tag operation failed\",\"detail\":\"The tag(s) %s could not be deleted\",\"errors\":{\"%s\":\"Tag does not exist\"}} (status: 400)",
+			tagID, tagID,
+		) {
+			tflog.Warn(ctx, "Unable to delete missing tag. Ignoring since is desired state.", map[string]any{
+				"id": state.ID.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete tag",
-			"Unexpected error when trying to delete tag: "+tagID+", from error: "+err.Error(),
+			"Unexpected error when trying to delete tag: "+tagID+", from error: "+err,
 		)
 		return
 	}

--- a/internal/provider/tag_resource_test.go
+++ b/internal/provider/tag_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccTagResource(t *testing.T) {
@@ -40,6 +41,58 @@ resource "dependencytrack_tag" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_tag.test", "id", "test_tags_tag_with_change"),
 					resource.TestCheckResourceAttr("dependencytrack_tag.test", "name", "test_tags_tag_with_change"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccTagResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Tag.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_tag" "test" {
+	name = "test_tag_236"
+}
+`,
+			},
+			// Duplicate reference to Tag.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_tag" "test" {
+	name = "test_tag_236"
+}
+resource "dependencytrack_tag" "test2" {
+	name = "test_tag_236"
+}
+import {
+	to = dependencytrack_tag.test2
+	id = dependencytrack_tag.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_tag.test", "id",
+						"dependencytrack_tag.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_tag" "test2" {
+	name = "test_tag_236"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_tag.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/team_apikey_resource.go
+++ b/internal/provider/team_apikey_resource.go
@@ -321,6 +321,7 @@ func (r *teamAPIKeyResource) Delete(ctx context.Context, req resource.DeleteRequ
 		err := err.Error()
 		if err == "The API key could not be found. (status: 404)" {
 			tflog.Warn(ctx, "Unable to delete missing Team API Key. Ignoring since is desired state.", map[string]any{
+				"id":     state.ID.ValueString(),
 				"team":   state.TeamID.ValueString(),
 				"masked": state.Masked.ValueString(),
 			})

--- a/internal/provider/team_apikey_resource.go
+++ b/internal/provider/team_apikey_resource.go
@@ -211,9 +211,19 @@ func (r *teamAPIKeyResource) Read(ctx context.Context, req resource.ReadRequest,
 		}
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Team API Key. Will be removed from state.", map[string]any{
+				"id":     state.ID.ValueString(),
+				"team":   state.TeamID.ValueString(),
+				"masked": state.Masked.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to find API Key",
-			"Unexpected error: "+err.Error(),
+			"Unexpected error: "+err,
 		)
 		return
 	}

--- a/internal/provider/team_apikey_resource.go
+++ b/internal/provider/team_apikey_resource.go
@@ -318,9 +318,17 @@ func (r *teamAPIKeyResource) Delete(ctx context.Context, req resource.DeleteRequ
 	})
 	err := r.client.Team.DeleteAPIKey(ctx, publicIDOrKey)
 	if err != nil {
+		err := err.Error()
+		if err == "The API key could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Team API Key. Ignoring since is desired state.", map[string]any{
+				"team":   state.TeamID.ValueString(),
+				"masked": state.Masked.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Team API Key",
-			"Unexpected error when trying to delete Team API Key: "+team.String()+", from error: "+err.Error(),
+			"Unexpected error when trying to delete Team API Key: "+team.String()+", from error: "+err,
 		)
 		return
 	}

--- a/internal/provider/team_apikey_resource_test.go
+++ b/internal/provider/team_apikey_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccTeamApiKeyResource(t *testing.T) {
@@ -114,6 +115,67 @@ resource "dependencytrack_team_apikey" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("dependencytrack_team_apikey.test", "comment", "Sample Update Comment"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAPIKeyResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial API Key.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_API_Key_236"
+}
+resource "dependencytrack_team_apikey" "test" {
+	team = dependencytrack_team.test.id
+}
+`,
+			},
+			// Duplicate reference to API Key.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_API_Key_236"
+}
+resource "dependencytrack_team_apikey" "test" {
+	team = dependencytrack_team.test.id
+}
+resource "dependencytrack_team_apikey" "test2" {
+	team = dependencytrack_team.test.id
+}
+import {
+	to = dependencytrack_team_apikey.test2
+	id = dependencytrack_team_apikey.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_team_apikey.test", "id",
+						"dependencytrack_team_apikey.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_API_Key_236"
+}
+resource "dependencytrack_team_apikey" "test2" {
+	team = dependencytrack_team.test.id
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_team_apikey.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/team_permission_resource.go
+++ b/internal/provider/team_permission_resource.go
@@ -135,9 +135,18 @@ func (r *teamPermissionResource) Read(ctx context.Context, req resource.ReadRequ
 		return permission.Name == state.Permission.ValueString()
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing Team Permission. Will be removed from state.", map[string]any{
+				"team":       state.TeamID.ValueString(),
+				"permission": state.Permission.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to identify team permission",
-			"Unexpected Error from: "+err.Error(),
+			"Unexpected Error from: "+err,
 		)
 		return
 	}

--- a/internal/provider/team_permission_resource_test.go
+++ b/internal/provider/team_permission_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccTeamPermissionResource(t *testing.T) {
@@ -48,6 +49,75 @@ resource "dependencytrack_team_permission" "test" {
 					),
 					resource.TestCheckResourceAttr("dependencytrack_team_permission.test", "permission", "BOM_UPLOAD"),
 				),
+			},
+		},
+	})
+}
+
+// NOTE: Since `dependencytrack_team_permission` does not implement `Import`, cannot duplicate reference in state.
+// Removing a Permission from a Team is a 200 OK response regardless of whether it was applied, in both API v4, v5.
+// So `Delete` works seemlessly, manually verified after artificially inserting multiple `dependencytrack_team_permission`'s into tfstate.
+func TestAccTeamPermissionResourceRegression236(t *testing.T) {
+	t.SkipNow()
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Team Permission.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_Team_Permission_236"
+}
+resource "dependencytrack_team_permission" "test" {
+	team = dependencytrack_team.test.id
+	permission = "BOM_UPLOAD"
+}
+`,
+			},
+			// Duplicate reference to Team Permission.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_Team_Permission_236"
+}
+resource "dependencytrack_team_permission" "test" {
+	team = dependencytrack_team.test.id
+	permission = "BOM_UPLOAD"
+}
+resource "dependencytrack_team_permission" "test2" {
+	team = dependencytrack_team.test.id
+	permission = "BOM_UPLOAD"
+}
+import {
+	to = dependencytrack_team_permission.test2
+	id = dependencytrack_team_permission.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_team_permission.test", "id",
+						"dependencytrack_team_permission.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_Team_Permission_236"
+}
+resource "dependencytrack_team_permission" "test2" {
+	team = dependencytrack_team.test.id
+	permission = "BOM_UPLOAD"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_team_permission.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/team_permission_resource_test.go
+++ b/internal/provider/team_permission_resource_test.go
@@ -56,7 +56,7 @@ resource "dependencytrack_team_permission" "test" {
 
 // NOTE: Since `dependencytrack_team_permission` does not implement `Import`, cannot duplicate reference in state.
 // Removing a Permission from a Team is a 200 OK response regardless of whether it was applied, in both API v4, v5.
-// So `Delete` works seemlessly, manually verified after artificially inserting multiple `dependencytrack_team_permission`'s into tfstate.
+// So `Delete` works seamlessly, manually verified after artificially inserting multiple `dependencytrack_team_permission`'s into tfstate against v5.1.0.
 func TestAccTeamPermissionResourceRegression236(t *testing.T) {
 	t.SkipNow()
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -221,7 +221,8 @@ func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	})
 	err := r.client.Team.Delete(ctx, team)
 	if err != nil {
-		if err.Error() == "The team could not be found. (status: 404)" {
+		err := err.Error()
+		if err == "The team could not be found. (status: 404)" {
 			tflog.Warn(ctx, "Could not delete missing team. Ignoring since in desired state.", map[string]any{
 				"id":   state.ID.ValueString(),
 				"name": state.Name.ValueString(),
@@ -230,7 +231,7 @@ func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		}
 		resp.Diagnostics.AddError(
 			"Unable to delete team",
-			"Unexpected error when trying to delete team: "+id.String()+", error: "+err.Error(),
+			"Unexpected error when trying to delete team: "+id.String()+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -116,9 +116,18 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	})
 	team, err := r.client.Team.Get(ctx, teamID)
 	if err != nil {
+		err := err.Error()
+		if err == "The team could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Missing team when attempting to read. Will be removed from state", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to get updated team",
-			"Error with reading team: "+teamID.String()+", in original error: "+err.Error(),
+			"Error with reading team: "+teamID.String()+", in original error: "+err,
 		)
 		return
 	}
@@ -212,6 +221,13 @@ func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	})
 	err := r.client.Team.Delete(ctx, team)
 	if err != nil {
+		if err.Error() == "The team could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Could not delete missing team. Ignoring since in desired state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete team",
 			"Unexpected error when trying to delete team: "+id.String()+", error: "+err.Error(),

--- a/internal/provider/team_resource_test.go
+++ b/internal/provider/team_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccTeamResource(t *testing.T) {
@@ -46,6 +47,9 @@ resource "dependencytrack_team" "test" {
 
 func TestAccTeamResourceRegression236(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	// Only checks `Delete` accounting for absence, and not `Read`. Manually checked at time of implementation.
+	// Previous attempts to only delete one, resulted in a non-empty plan refresh, where both had been removed from State.
+	//	And so was trying to create remaining, which could not be disregarded.
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -78,13 +82,15 @@ import {
 					),
 				),
 			},
-			// Delete initial team, and read copied reference.
+			// Remove one `dependencytrack_team`, removing Team within DT.
+			// Causing other when attempting to be deleted, to account for it's absence without error.
 			{
-				Config: providerConfig + `
-resource "dependencytrack_team" "test2" {
-	name = "Test_Team_236"
-}
-`,
+				Config: providerConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/internal/provider/team_resource_test.go
+++ b/internal/provider/team_resource_test.go
@@ -47,9 +47,6 @@ resource "dependencytrack_team" "test" {
 
 func TestAccTeamResourceRegression236(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
-	// Only checks `Delete` accounting for absence, and not `Read`. Manually checked at time of implementation.
-	// Previous attempts to only delete one, resulted in a non-empty plan refresh, where both had been removed from State.
-	//	And so was trying to create remaining, which could not be disregarded.
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -85,12 +82,17 @@ import {
 			// Remove one `dependencytrack_team`, removing Team within DT.
 			// Causing other when attempting to be deleted, to account for it's absence without error.
 			{
-				Config: providerConfig,
+				Config: providerConfig + `
+resource "dependencytrack_team" "test2" {
+	name = "Test_Team_236"
+}
+`,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectResourceAction("dependencytrack_team.test2", "Create"),
 					},
 				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/team_resource_test.go
+++ b/internal/provider/team_resource_test.go
@@ -43,3 +43,49 @@ resource "dependencytrack_team" "test" {
 		},
 	})
 }
+
+func TestAccTeamResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial team.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_Team_236"
+}
+`,
+			},
+			// Duplicate reference to team.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test" {
+	name = "Test_Team_236"
+}
+resource "dependencytrack_team" "test2" {
+	name = "Test_Team_236"
+}
+import {
+	to = dependencytrack_team.test2
+	id = dependencytrack_team.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_team.test", "id",
+						"dependencytrack_team.test2", "id",
+					),
+				),
+			},
+			// Delete initial team, and read copied reference.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_team" "test2" {
+	name = "Test_Team_236"
+}
+`,
+			},
+		},
+	})
+}

--- a/internal/provider/user_permission_resource.go
+++ b/internal/provider/user_permission_resource.go
@@ -117,9 +117,18 @@ func (r *userPermissionResource) Read(ctx context.Context, req resource.ReadRequ
 	})
 	user, err := FindUserPrincipal(ctx, *r.client, username)
 	if err != nil {
+		err := err.Error()
+		if err == "could not find user" {
+			tflog.Warn(ctx, "Unable to read User Missing due to missing User. Will be removed from state.", map[string]any{
+				"username":   state.Username.ValueString(),
+				"permission": state.Permission.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to get updated user",
-			"Error with reading user: "+username+", in original error: "+err.Error(),
+			"Error with reading user: "+username+", in original error: "+err,
 		)
 		return
 	}
@@ -127,9 +136,18 @@ func (r *userPermissionResource) Read(ctx context.Context, req resource.ReadRequ
 		return permission.Name == state.Permission.ValueString()
 	})
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing User Permission. Will be removed from state.", map[string]any{
+				"username":   state.Username.ValueString(),
+				"permission": state.Permission.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to identify user permission",
-			"Unexpected Error from: "+err.Error(),
+			"Unexpected Error from: "+err,
 		)
 		return
 	}

--- a/internal/provider/user_permission_resource.go
+++ b/internal/provider/user_permission_resource.go
@@ -119,7 +119,7 @@ func (r *userPermissionResource) Read(ctx context.Context, req resource.ReadRequ
 	if err != nil {
 		err := err.Error()
 		if err == "could not find user" {
-			tflog.Warn(ctx, "Unable to read User Missing due to missing User. Will be removed from state.", map[string]any{
+			tflog.Warn(ctx, "Unable to read User Permission due to missing User. Will be removed from state.", map[string]any{
 				"username":   state.Username.ValueString(),
 				"permission": state.Permission.ValueString(),
 			})
@@ -212,9 +212,18 @@ func (r *userPermissionResource) Delete(ctx context.Context, req resource.Delete
 	})
 	_, err := r.client.Permission.RemovePermissionFromUser(ctx, permission, username)
 	if err != nil {
+		err := err.Error()
+		// TODO: Not covered by test - due to not implementing `Import`, based on static src review (v4.14.3, v5.1.0).
+		if err == "api error (status: 304)" {
+			tflog.Warn(ctx, "Unable to delete missing User Permission. Ignoring since is desired state.", map[string]any{
+				"username":   state.Username.ValueString(),
+				"permission": state.Permission.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete user permission",
-			"Unexpected error when trying to delete user permission: "+username+", error: "+err.Error(),
+			"Unexpected error when trying to delete user permission: "+username+", error: "+err,
 		)
 		return
 	}

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -334,9 +334,16 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	})
 	err := r.client.User.DeleteManaged(ctx, user)
 	if err != nil {
+		err := err.Error()
+		if err == "The user could not be found. (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing User. Ignoring since is desired state.", map[string]any{
+				"username": state.Username.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete managed user",
-			"Error for user: "+user.Username+", from original error: "+err.Error(),
+			"Error for user: "+user.Username+", from original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -194,9 +194,17 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		},
 	)
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing User. Will be removed from state.", map[string]any{
+				"username": state.Username.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to read managed user",
-			"Error for user: "+username+", in original error: "+err.Error(),
+			"Error for user: "+username+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccUserResource(t *testing.T) {
@@ -58,6 +59,67 @@ resource "dependencytrack_user" "test" {
 					resource.TestCheckResourceAttr("dependencytrack_user.test", "force_password_change", "false"),
 					resource.TestCheckResourceAttr("dependencytrack_user.test", "password_expires", "true"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccUserResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial User.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_user" "test" {
+	username = "Test_User_236"
+	fullname = "Test_User_236"
+	email = "Test_Email_236@example.com"
+	password = "Test_User_236"
+}
+`,
+			},
+			// Duplicate reference to User.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_user" "test" {
+	username = "Test_User_236"
+	fullname = "Test_User_236"
+	email = "Test_Email_236@example.com"
+}
+resource "dependencytrack_user" "test2" {
+	username = "Test_User_236"
+	fullname = "Test_User_236"
+	email = "Test_Email_236@example.com"
+}
+import {
+	to = dependencytrack_user.test2
+	id = dependencytrack_user.test.id
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_user.test", "id",
+						"dependencytrack_user.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_user" "test2" {
+	username = "Test_User_236"
+	fullname = "Test_User_236"
+	email = "Test_Email_236@example.com"
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_user.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/user_team_resource.go
+++ b/internal/provider/user_team_resource.go
@@ -124,17 +124,35 @@ func (r *userTeamResource) Read(ctx context.Context, req resource.ReadRequest, r
 	})
 	user, err := FindUserPrincipal(ctx, *r.client, username)
 	if err != nil {
+		err := err.Error()
+		if err == "could not find user" {
+			tflog.Warn(ctx, "Unable to read User Team due to missing User. Will be removed from state.", map[string]any{
+				"username": state.Username.ValueString(),
+				"team":     state.TeamID.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to read user",
-			"Error with reading user: "+username+", in original error: "+err.Error(),
+			"Error with reading user: "+username+", in original error: "+err,
 		)
 		return
 	}
 	team, err := Find(user.Teams, func(team dtrack.Team) bool { return team.UUID == teamID })
 	if err != nil {
+		err := err.Error()
+		if err == "did not find item" {
+			tflog.Warn(ctx, "Unable to read missing User Team. Will be removed from state.", map[string]any{
+				"username": state.Username.ValueString(),
+				"team":     state.TeamID.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Within Read, unable to identify user team membership",
-			"Error with locating team: "+teamID.String()+", for user: "+username+", in original error: "+err.Error(),
+			"Error with locating team: "+teamID.String()+", for user: "+username+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/user_team_resource.go
+++ b/internal/provider/user_team_resource.go
@@ -215,9 +215,19 @@ func (r *userTeamResource) Delete(ctx context.Context, req resource.DeleteReques
 	})
 	_, err := r.client.User.RemoveTeamFromUser(ctx, username, team)
 	if err != nil {
+		err := err.Error()
+		// TODO: Not covered by test, due to resource not implementing `Import`.
+		// Could not trigger with brief manual testing, so condition is from static review.
+		if err == "The user was not a member of the specified team. (status: 304)" {
+			tflog.Warn(ctx, "Unable to delete missing User Team. Ignoring since is desired state.", map[string]any{
+				"username": state.Username.ValueString(),
+				"team":     state.TeamID.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete user team membership",
-			"Error with username: "+username+", for team: "+team.String()+", in original error: "+err.Error(),
+			"Error with username: "+username+", for team: "+team.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/vulnerability_policy_resource.go
+++ b/internal/provider/vulnerability_policy_resource.go
@@ -542,9 +542,17 @@ func (r *vulnerabilityPolicyResource) Delete(ctx context.Context, req resource.D
 	})
 	err := r.client.VulnerabilityPolicy.Delete(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "{\"type\":\"about:blank\",\"title\":\"Not Found\",\"detail\":\"The requested resource could not be found.\",\"status\":404} (status: 404)" {
+			tflog.Warn(ctx, "Unable to delete missing Vulnerability Policy. Ignoring since is desired state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to delete Vulnerability Policy",
-			"Unexpected error when trying to delete Vulnerability Policy: "+id.String()+", from error: "+err.Error(),
+			"Unexpected error when trying to delete Vulnerability Policy: "+id.String()+", from error: "+err,
 		)
 		return
 	}

--- a/internal/provider/vulnerability_policy_resource.go
+++ b/internal/provider/vulnerability_policy_resource.go
@@ -307,9 +307,18 @@ func (r *vulnerabilityPolicyResource) Read(ctx context.Context, req resource.Rea
 
 	policy, err := r.client.VulnerabilityPolicy.Get(ctx, id)
 	if err != nil {
+		err := err.Error()
+		if err == "{\"type\":\"about:blank\",\"title\":\"Not Found\",\"detail\":\"The requested resource could not be found.\",\"status\":404} (status: 404)" {
+			tflog.Warn(ctx, "Unable to read missng Vulnerability Policy. Will be removed from state.", map[string]any{
+				"id":   state.ID.ValueString(),
+				"name": state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error when reading Vulnerability Policy.",
-			"Error in policy with id: "+id.String()+", in original error: "+err.Error(),
+			"Error in policy with id: "+id.String()+", in original error: "+err,
 		)
 		return
 	}

--- a/internal/provider/vulnerability_policy_resource.go
+++ b/internal/provider/vulnerability_policy_resource.go
@@ -309,7 +309,7 @@ func (r *vulnerabilityPolicyResource) Read(ctx context.Context, req resource.Rea
 	if err != nil {
 		err := err.Error()
 		if err == "{\"type\":\"about:blank\",\"title\":\"Not Found\",\"detail\":\"The requested resource could not be found.\",\"status\":404} (status: 404)" {
-			tflog.Warn(ctx, "Unable to read missng Vulnerability Policy. Will be removed from state.", map[string]any{
+			tflog.Warn(ctx, "Unable to read missing Vulnerability Policy. Will be removed from state.", map[string]any{
 				"id":   state.ID.ValueString(),
 				"name": state.Name.ValueString(),
 			})

--- a/internal/provider/vulnerability_policy_resource_test.go
+++ b/internal/provider/vulnerability_policy_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 // API 5+.
@@ -75,6 +76,78 @@ resource "dependencytrack_vulnerability_policy" "test" {
 					resource.TestCheckResourceAttrSet("dependencytrack_vulnerability_policy.test", "created"),
 					resource.TestCheckResourceAttrSet("dependencytrack_vulnerability_policy.test", "updated"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccVulnerabilityPolicyResourceRegression236(t *testing.T) {
+	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create initial Vulnerability Policy.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_vulnerability_policy" "test" {
+	name = "Test_Vulnerability_Policy_236"
+	condition = "true"
+	analysis = {
+		state = "EXPLOITABLE"
+	}
+	ratings = []
+}
+`,
+			},
+			// Duplicate reference to Vulnerability Policy.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_vulnerability_policy" "test" {
+	name = "Test_Vulnerability_Policy_236"
+	condition = "true"
+	analysis = {
+		state = "EXPLOITABLE"
+	}
+	ratings = []
+}
+resource "dependencytrack_vulnerability_policy" "test2" {
+	name = "Test_Vulnerability_Policy_236"
+	condition = "true"
+	analysis = {
+		state = "EXPLOITABLE"
+	}
+	ratings = []
+}
+import {
+	to = dependencytrack_vulnerability_policy.test2
+	id = dependencytrack_vulnerability_policy.test.id
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"dependencytrack_vulnerability_policy.test", "id",
+						"dependencytrack_vulnerability_policy.test2", "id",
+					),
+				),
+			},
+			// Delete one.
+			{
+				Config: providerConfig + `
+resource "dependencytrack_vulnerability_policy" "test2" {
+	name = "Test_Vulnerability_Policy_236"
+	condition = "true"
+	analysis = {
+		state = "EXPLOITABLE"
+	}
+	ratings = []
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("dependencytrack_vulnerability_policy.test2", "Create"),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
- Implements fix for #236.
- Change `Read` functions to remove a resource from state, if it has been removed from DT API server.
- Change `Delete` functions to pass with warning, if deleting a resource fails due to it having been removed from DT API server.
- Add series of regression tests for numerous resources that were deemed to be susceptible to same bug, even if not originally reported.
- Fix incorrect log messages within `Import` for `dependencytrack_config_property`, mentioning `Read`.