### PR TITLE
Testing Semver Conditions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 15
     services:
       api:
-        image: dependencytrack/apiserver:${{ matrix.api.version }}
+        image: dependencytrack/apiserver:${{ matrix.api_version }}
         env:
           # TODO: Use external (to DT) DB
           #ALPINE_DATABASE_MODE: external
@@ -166,7 +166,7 @@ jobs:
       matrix:
         terraform:
          - '1.15.*'
-        api:
+        api_version:
           - "4.11.7"
           - "4.12.7"
           - "4.13.0"
@@ -185,7 +185,6 @@ jobs:
       - uses: ./.github/actions/test
         with:
           terraform_version: ${{ matrix.terraform }}
-          tests_skip_regex: ${{ matrix.api.skip }}
 
   test_v4_comprehensive:
     # Test across range of Terraform versions.
@@ -197,7 +196,7 @@ jobs:
     timeout-minutes: 15
     services:
       api:
-        image: dependencytrack/apiserver:${{ matrix.api.version }}
+        image: dependencytrack/apiserver:${{ matrix.api_version }}
         env:
           # TODO: Use external (to DT) DB
           #ALPINE_DATABASE_MODE: external
@@ -235,7 +234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api:
+        api_version:
           - "4.11.7"
           - "4.12.7"
           - "4.13.0"
@@ -270,7 +269,6 @@ jobs:
       - uses: ./.github/actions/test
         with:
           terraform_version: ${{ matrix.terraform }}
-          tests_skip_regex: ${{ matrix.api.skip }}
 
   test_v5:
     # Test with just the latest testing version of Terraform, so that have one matrix with one instance per API version, to allow for easier navigating of jobs.
@@ -300,7 +298,7 @@ jobs:
       matrix:
         terraform:
          - '1.15.*'
-        api:
+        api_version:
           - "5.0.2"
           - "5.0.5"
           - "5.1.0"
@@ -309,8 +307,7 @@ jobs:
       - uses: ./.github/actions/test-v5
         with:
           terraform_version: ${{ matrix.terraform }}
-          api_version: ${{ matrix.api.version }}
-          tests_skip: ${{ matrix.api.skip }}
+          api_version: ${{ matrix.api_version }}
 
   test_v5_comprehensive:
     # Test across range of Terraform versions.
@@ -338,7 +335,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api:
+        api_version:
           - "5.0.2"
           - "5.0.5"
           - "5.1.0"
@@ -363,5 +360,4 @@ jobs:
       - uses: ./.github/actions/test-v5
         with:
           terraform_version: ${{ matrix.terraform }}
-          api_version: ${{ matrix.api.version }}
-          tests_skip: ${{ matrix.api.skip }}
+          api_version: ${{ matrix.api_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 15
     services:
       api:
-        image: dependencytrack/apiserver:${{ matrix.api.version }}
+        image: dependencytrack/apiserver:${{ matrix.api_version }}
         env:
           # TODO: Use external (to DT) DB
           #ALPINE_DATABASE_MODE: external
@@ -159,33 +159,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api:
-          - version: "4.11.7"
-            skip: "^(TestAccTagResource)|(TestAccProjectTagsRead)|(TestAccTagPoliciesResource)|(TestAccTagProjectsResource)|(TestAccProjectCollection)|(TestAccProjectIsLatest)|(TestAccProjectDataSourceIsLatest)|(TestAccNotificationRuleScheduleResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.12.7"
-            skip: "^(TestAccTagResource)|(TestAccProjectCollection)|(TestAccNotificationRuleScheduleResource)|(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.13.0"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.13.1"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.13.2"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.13.3"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.13.4"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.13.5"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.13.6-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.14.0-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.14.1-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.14.2-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
-          - version: "4.14.3-alpine"
-            skip: "^(TestAccVulnerabilityPolicyResource)|(TestAccVulnerabilityPolicyResourceRegression236)$"
+        api_version:
+          - "4.11.7"
+          - "4.12.7"
+          - "4.13.0"
+          - "4.13.1"
+          - "4.13.2"
+          - "4.13.3"
+          - "4.13.4"
+          - "4.13.5"
+          - "4.13.6-alpine"
+          - "4.14.0-alpine"
+          - "4.14.1-alpine"
+          - "4.14.2-alpine"
+          - "4.14.3-alpine"
         terraform:
           - '1.0.*'
           - '1.1.*'
@@ -213,8 +200,6 @@ jobs:
       - uses: ./.github/actions/test
         with:
           terraform_version: ${{ matrix.terraform }}
-          tests_skip_regex: ${{ matrix.api.skip }}
-
 
   test_v5:
     name: Terraform Provider Acceptance Tests API v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,16 +226,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api:
-          - version: "5.0.2"
-            # Currently failing tests, which will require adjusting implementation to properly fix.
-            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccNotificationRuleResourceRegression236)$"
-          - version: "5.0.5"
-            # Currently failing tests, which will require adjusting implementation to properly fix.
-            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccNotificationRuleResourceRegression236)$"
-          - version: "5.1.0"
-            # Currently failing tests, which will require adjusting implementation to properly fix.
-            skip: "^(TestAccConfigPropertiesResource)|(TestAccConfigPropertiesResourceRegression149)|(TestAccConfigPropertyResource)|(TestAccConfigPropertyResourceRegression149)|(TestAccNotificationPublisherDataSource)|(TestAccNotificationPublisherResource)|(TestAccNotificationRuleProjectResource)|(TestAccNotificationRuleEventResource)|(TestAccNotificationRuleScheduleResource)|(TestAccNotificationRuleTeamResource)|(TestAccProjectDataSource)|(TestAccProjectPropertyResource)|(TestAccProjectCollection)|(TestAccRepositoryResource)|(TestAccTagNotificationRulesResource)|(TestAccTagNotificationRulesResourceNotificationRulesUnordered)|(TestAccNotificationRuleResourceRegression236)$"
+        api_version:
+          - "5.0.2"
+          - "5.0.5"
+          - "5.1.0"
         terraform:
           - '1.0.*'
           - '1.1.*'
@@ -300,7 +294,7 @@ jobs:
           --name 'api' \
           --read-only \
           --rm \
-          ghcr.io/dependencytrack/apiserver:${{ matrix.api.version }}
+          ghcr.io/dependencytrack/apiserver:${{ matrix.api_version }}
       - name: Wait for Healthy
         run: |
           while [ "$(docker inspect -f {{.State.Health.Status}} api)" != "healthy" ]; do sleep 1; done
@@ -312,7 +306,6 @@ jobs:
       - uses: ./.github/actions/test
         with:
           terraform_version: ${{ matrix.terraform }}
-          tests_skip_regex: ${{ matrix.api.skip }}
           provider_config_key: 'v5'
       - name: API Container Logs
         run: docker logs api

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -651,6 +651,12 @@ linters:
       - path: internal/provider/user_permission_resource.go
         linters:
           - godox
+      - path: internal/provider/config_properties_resource_test.go
+        linters:
+          - godox
+      - path: internal/provider/config_property_resource_test.go
+        linters:
+          - godox
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -495,6 +495,7 @@ linters:
       ignore-names: # Default []
         - r
         - d
+        - p
       ignore-decls: # Default []
         - t *transport
         - id uuid.UUID
@@ -555,6 +556,7 @@ linters:
       - path: internal/provider/provider_test.go
         linters:
           - gochecknoglobals
+          - exhaustruct_v5
       - path: internal/provider/project_resource.go
         linters:
           - gocyclo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -557,6 +557,9 @@ linters:
         linters:
           - gochecknoglobals
           - exhaustruct_v5
+          - errcheck
+          - revive
+          - forbidigo
       - path: internal/provider/project_resource.go
         linters:
           - gocyclo

--- a/internal/provider/config_properties_resource_test.go
+++ b/internal/provider/config_properties_resource_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestAccConfigPropertiesResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		// TODO: Email is just an example, so can be moved to a config property that was not removed.
+		t.Skip("TODO: Email config was removed from config properties, and moved to an extension point.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -114,6 +118,10 @@ resource "dependencytrack_config_properties" "test" {
 
 func TestAccConfigPropertiesResourceRegression149(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/149
+	if apiSemver.Major > 4 {
+		// NOTE: Similar test will be required when adding the relevant extension point to re-enable this management under v5.
+		t.Skip("TODO: OSV config was removed from config properties, and moved to an extension point.")
+	}
 	//	Default return value for `google.osv.enabled` is a sorted list, e.g. `Debian;Alpine;NuGet` / `Debian;Go;Alpine;NuGet`.
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/config_property_resource_test.go
+++ b/internal/provider/config_property_resource_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestAccConfigPropertyResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		// TODO: Email is just an example config, so can be changed to something else that did not get removed.
+		t.Skip("TODO: Email config was removed from config properties, and moved to an extension point.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -126,6 +130,10 @@ resource "dependencytrack_config_property" "testencrypted" {
 
 func TestAccConfigPropertyResourceRegression149(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/149
+	if apiSemver.Major > 4 {
+		// NOTE: Will need similar test when relevant extension-point is added to re-enable this management in v5.
+		t.Skip("TODO: OSV configuration was removed from config properties, and moved to an extension point.")
+	}
 	//	Default return value for `google.osv.enabled` is a sorted list, e.g. `Debian;Alpine;NuGet` / `Debian;Go;Alpine;NuGet`.
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/notification_publisher_data_source_test.go
+++ b/internal/provider/notification_publisher_data_source_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAccNotificationPublisherDataSource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema has changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/notification_publisher_resource_test.go
+++ b/internal/provider/notification_publisher_resource_test.go
@@ -67,6 +67,9 @@ resource "dependencytrack_notification_publisher" "test" {
 }
 
 func TestAccNotificationPublisherResourceRegression236(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/notification_publisher_resource_test.go
+++ b/internal/provider/notification_publisher_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccNotificationPublisherResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/notification_rule_project_resource_test.go
+++ b/internal/provider/notification_rule_project_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccNotificationRuleProjectResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/notification_rule_project_resource_test.go
+++ b/internal/provider/notification_rule_project_resource_test.go
@@ -93,6 +93,9 @@ resource "dependencytrack_notification_rule_project" "test" {
 
 func TestAccNotificationRuleProjectResourceRegression236(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/notification_rule_resource_test.go
+++ b/internal/provider/notification_rule_resource_test.go
@@ -91,8 +91,11 @@ resource "dependencytrack_notification_rule" "test" {
 	})
 }
 
+// API 4.13+.
 func TestAccNotificationRuleScheduleResource(t *testing.T) {
-	// API 4.13+.
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 13) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/notification_rule_resource_test.go
+++ b/internal/provider/notification_rule_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccNotificationRuleEventResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -96,6 +99,9 @@ func TestAccNotificationRuleScheduleResource(t *testing.T) {
 	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 13) {
 		t.SkipNow()
 	}
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -178,6 +184,9 @@ resource "dependencytrack_notification_rule" "test" {
 
 func TestAccNotificationRuleResourceRegression236(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/notification_rule_team_resource_test.go
+++ b/internal/provider/notification_rule_team_resource_test.go
@@ -93,6 +93,9 @@ resource "dependencytrack_notification_rule_team" "test" {
 
 func TestAccNotificationRuleTeamResourceRegression236(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/notification_rule_team_resource_test.go
+++ b/internal/provider/notification_rule_team_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccNotificationRuleTeamResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/project_data_source_test.go
+++ b/internal/provider/project_data_source_test.go
@@ -51,6 +51,9 @@ data "dependencytrack_project" "test" {
 
 // API 4.12+.
 func TestAccProjectDataSourceIsLatest(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/project_data_source_test.go
+++ b/internal/provider/project_data_source_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAccProjectDataSource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Properties no longer sent by API in request. Make additional request to obtain.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/project_property_resource_test.go
+++ b/internal/provider/project_property_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccProjectPropertyResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: ENCRYPTEDSTRING was removed, and replaced with dedicated secrets management. Split into two tests.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -227,6 +227,9 @@ resource "dependencytrack_project" "test" {
 }
 
 func TestAccProjectTagsRead(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -316,6 +319,9 @@ data "dependencytrack_project" "project2" {
 
 // API 4.13+.
 func TestAccProjectCollection(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 13) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -409,6 +415,9 @@ resource "dependencytrack_project" "test3" {
 
 // API 4.12+.
 func TestAccProjectIsLatest(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -322,6 +322,9 @@ func TestAccProjectCollection(t *testing.T) {
 	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 13) {
 		t.SkipNow()
 	}
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Explicit logic of NONE is not valid in v5. Split into two tests.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -143,7 +143,7 @@ func (*dependencyTrackProvider) Schema(_ context.Context, _ provider.SchemaReque
 	}
 }
 
-func (*dependencyTrackProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+func (p *dependencyTrackProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	// Get provider data from config.
 	var config dependencyTrackProviderModel
 	diags := req.Config.Get(ctx, &config)
@@ -152,56 +152,14 @@ func (*dependencyTrackProvider) Configure(ctx context.Context, req provider.Conf
 		return
 	}
 
-	host := config.Host.ValueString()
-	if host == "" {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("host"),
-			"Missing DependencyTrack Host",
-			"Host for DependencyTrack was provided, but it was empty.",
-		)
-	}
-	authClientOption := getAuthClientOption(config, &resp.Diagnostics)
-	httpClient := getHTTPClient(config, &resp.Diagnostics)
-
+	info := p.configureImpl(ctx, config, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Debug(ctx, "Creating DependencyTrack client")
-	client, err := dtrack.NewClient(host, dtrack.WithHttpClient(httpClient), authClientOption)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create DependencyTrack API Client",
-			"An Unexpected error occurred when creating the DependencyTrack API Client. "+err.Error(),
-		)
-		return
-	}
+	resp.DataSourceData = *info
+	resp.ResourceData = *info
 
-	version, err := client.About.Get(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to retrieve DependencyTrack API Version",
-			"Error from: "+err.Error(),
-		)
-		return
-	}
-	semver, err := ParseSemver(version.Version)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to parse DependencyTrack API Version",
-			"Error from: "+err.Error(),
-		)
-		return
-	}
-
-	resp.DataSourceData = clientInfo{
-		client: client,
-		semver: semver,
-	}
-	resp.ResourceData = clientInfo{
-		client: client,
-		semver: semver,
-	}
 	tflog.Debug(ctx, "Configured DependencyTrack client", map[string]any{
 		"success": true,
 	})
@@ -269,6 +227,56 @@ func New(version string) func() provider.Provider {
 			version: version,
 		}
 	}
+}
+
+func (*dependencyTrackProvider) configureImpl(ctx context.Context, config dependencyTrackProviderModel, diags *diag.Diagnostics) *clientInfo {
+	host := config.Host.ValueString()
+	if host == "" {
+		diags.AddAttributeError(
+			path.Root("host"),
+			"Missing DependencyTrack Host",
+			"Host for DependencyTrack was provided, but it was empty.",
+		)
+	}
+	authClientOption := getAuthClientOption(config, diags)
+	httpClient := getHTTPClient(config, diags)
+
+	if diags.HasError() {
+		return nil
+	}
+
+	tflog.Debug(ctx, "Creating DependencyTrack client")
+	client, err := dtrack.NewClient(host, dtrack.WithHttpClient(httpClient), authClientOption)
+	if err != nil {
+		diags.AddError(
+			"Unable to Create DependencyTrack API Client",
+			"An Unexpected error occurred when creating the DependencyTrack API Client. "+err.Error(),
+		)
+		return nil
+	}
+
+	version, err := client.About.Get(ctx)
+	if err != nil {
+		diags.AddError(
+			"Unable to retrieve DependencyTrack API Version",
+			"Error from: "+err.Error(),
+		)
+		return nil
+	}
+	semver, err := ParseSemver(version.Version)
+	if err != nil {
+		diags.AddError(
+			"Unable to parse DependencyTrack API Version",
+			"Error from: "+err.Error(),
+		)
+		return nil
+	}
+
+	info := clientInfo{
+		client: client,
+		semver: semver,
+	}
+	return &info
 }
 
 func getHTTPClient(config dependencyTrackProviderModel, diagnostics *diag.Diagnostics) *http.Client {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -125,7 +125,7 @@ var (
 		}
 	}
 
-	getClientSemver = func(option string) Semver {
+	getAPISemver = func(option string) Semver {
 		config := getClientConfig(option)
 		prov := dependencyTrackProvider{version: "test"}
 		diags := diag.Diagnostics{}
@@ -139,7 +139,7 @@ var (
 		return *clientInfo.semver
 	}
 
-	clientSemver = getClientSemver(os.Getenv("DEPENDENCYTRACK_TEST_PROVIDER"))
+	apiSemver = getAPISemver(os.Getenv("DEPENDENCYTRACK_TEST_PROVIDER"))
 
 	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"dependencytrack": providerserver.NewProtocol6WithError(New("test")()),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -74,11 +75,10 @@ var (
 			if err != nil {
 				panic("Root CA file is unable to be read: " + err.Error())
 			}
-			rootCaStr := strings.ReplaceAll(string(rootCa), "\n", "\\n")
 			return dependencyTrackProviderModel{
 				Host:   types.StringValue("https://localhost:8082"),
 				Key:    types.StringValue("OS_ENV"),
-				RootCA: types.StringValue(rootCaStr),
+				RootCA: types.StringValue(string(rootCa)),
 			}
 		}
 		if option == "mtls" {
@@ -99,14 +99,13 @@ var (
 			if err != nil {
 				panic("Root CA file is unable to be read: " + err.Error())
 			}
-			rootCaStr := strings.ReplaceAll(string(rootCa), "\n", "\\n")
 			return dependencyTrackProviderModel{
 				Host: types.StringValue("https://localhost:8084"),
 				Auth: &providerAuthModel{
 					Type: types.StringValue("KEY"),
 					Key:  types.StringValue("OS_ENV"),
 				},
-				RootCA: types.StringValue(rootCaStr),
+				RootCA: types.StringValue(string(rootCa)),
 				MTLS: &dependencyTrackProviderMtlsModel{
 					KeyPath:  types.StringValue("/opt/client_key.pem"),
 					CertPath: types.StringValue("/opt/client_cert.pem"),
@@ -131,6 +130,9 @@ var (
 		diags := diag.Diagnostics{}
 		clientInfo := prov.configureImpl(context.Background(), config, &diags)
 		if diags.HasError() {
+			for _, diagnostic := range diags {
+				fmt.Printf("Diagnostic error: %v\n", diagnostic)
+			}
 			panic("Test Provider has diagnostic errors, when creating.")
 		}
 		if clientInfo == nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,10 +1,13 @@
 package provider
 
 import (
+	"context"
 	"os"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
@@ -64,6 +67,79 @@ var (
 			key = "OS_ENV"
 		}`
 	}()
+
+	getClientConfig = func(option string) dependencyTrackProviderModel {
+		if option == "rootCA" {
+			rootCa, err := os.ReadFile("/opt/server_cert.pem")
+			if err != nil {
+				panic("Root CA file is unable to be read: " + err.Error())
+			}
+			rootCaStr := strings.ReplaceAll(string(rootCa), "\n", "\\n")
+			return dependencyTrackProviderModel{
+				Host:   types.StringValue("https://localhost:8082"),
+				Key:    types.StringValue("OS_ENV"),
+				RootCA: types.StringValue(rootCaStr),
+			}
+		}
+		if option == "mtls" {
+			return dependencyTrackProviderModel{
+				Host: types.StringValue("http://localhost:8083"),
+				Auth: &providerAuthModel{
+					Type: types.StringValue("KEY"),
+					Key:  types.StringValue("OS_ENV"),
+				},
+				MTLS: &dependencyTrackProviderMtlsModel{
+					KeyPath:  types.StringValue("/opt/client_key.pem"),
+					CertPath: types.StringValue("/opt/client_cert.pem"),
+				},
+			}
+		}
+		if option == "rootCA+mtls" {
+			rootCa, err := os.ReadFile("/opt/server_cert.pem")
+			if err != nil {
+				panic("Root CA file is unable to be read: " + err.Error())
+			}
+			rootCaStr := strings.ReplaceAll(string(rootCa), "\n", "\\n")
+			return dependencyTrackProviderModel{
+				Host: types.StringValue("https://localhost:8084"),
+				Auth: &providerAuthModel{
+					Type: types.StringValue("KEY"),
+					Key:  types.StringValue("OS_ENV"),
+				},
+				RootCA: types.StringValue(rootCaStr),
+				MTLS: &dependencyTrackProviderMtlsModel{
+					KeyPath:  types.StringValue("/opt/client_key.pem"),
+					CertPath: types.StringValue("/opt/client_cert.pem"),
+				},
+			}
+		}
+		if option == "v5" {
+			return dependencyTrackProviderModel{
+				Host: types.StringValue("http://localhost:9081"),
+				Key:  types.StringValue("OS_ENV"),
+			}
+		}
+		return dependencyTrackProviderModel{
+			Host: types.StringValue("http://localhost:8081"),
+			Key:  types.StringValue("OS_ENV"),
+		}
+	}
+
+	getClientSemver = func(option string) Semver {
+		config := getClientConfig(option)
+		prov := dependencyTrackProvider{version: "test"}
+		diags := diag.Diagnostics{}
+		clientInfo := prov.configureImpl(context.Background(), config, &diags)
+		if diags.HasError() {
+			panic("Test Provider has diagnostic errors, when creating.")
+		}
+		if clientInfo == nil {
+			panic("Test Provider creation returned nil clientInfo.")
+		}
+		return *clientInfo.semver
+	}
+
+	clientSemver = getClientSemver(os.Getenv("DEPENDENCYTRACK_TEST_PROVIDER"))
 
 	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"dependencytrack": providerserver.NewProtocol6WithError(New("test")()),

--- a/internal/provider/repository_resource_test.go
+++ b/internal/provider/repository_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccRepositoryResource(t *testing.T) {
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: password field has changed from value, to being a name of a managed secret. Will need Secrets Management resource, and splitting into two tests.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/tag_notification_rules_resource_test.go
+++ b/internal/provider/tag_notification_rules_resource_test.go
@@ -10,6 +10,9 @@ func TestAccTagNotificationRulesResource(t *testing.T) {
 	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
 		t.SkipNow()
 	}
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -127,6 +130,9 @@ resource "dependencytrack_tag_notification_rules" "test" {
 func TestAccTagNotificationRulesResourceNotificationRulesUnordered(t *testing.T) {
 	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
 		t.SkipNow()
+	}
+	if apiSemver.Major > 4 {
+		t.Skip("TODO: Notification Publisher API schema changed in v5.")
 	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/tag_notification_rules_resource_test.go
+++ b/internal/provider/tag_notification_rules_resource_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAccTagNotificationRulesResource(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -122,6 +125,9 @@ resource "dependencytrack_tag_notification_rules" "test" {
 }
 
 func TestAccTagNotificationRulesResourceNotificationRulesUnordered(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/tag_policies_resource_test.go
+++ b/internal/provider/tag_policies_resource_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAccTagPoliciesResource(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/tag_policies_resource_test.go
+++ b/internal/provider/tag_policies_resource_test.go
@@ -103,6 +103,9 @@ resource "dependencytrack_tag_policies" "test" {
 }
 
 func TestAccTagPoliciesResourcePoliciesUnordered(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/tag_projects_resource_test.go
+++ b/internal/provider/tag_projects_resource_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAccTagProjectsResource(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/tag_projects_resource_test.go
+++ b/internal/provider/tag_projects_resource_test.go
@@ -95,6 +95,9 @@ data "dependencytrack_project" "test2" {
 }
 
 func TestAccTagProjectsResourceProjectsUnordered(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 12) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/tag_resource_test.go
+++ b/internal/provider/tag_resource_test.go
@@ -51,6 +51,9 @@ resource "dependencytrack_tag" "test" {
 
 func TestAccTagResourceRegression236(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 13) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/tag_resource_test.go
+++ b/internal/provider/tag_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccTagResource(t *testing.T) {
+	if apiSemver.Major < 4 || (apiSemver.Major == 4 && apiSemver.Minor < 13) {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/vulnerability_policy_resource_test.go
+++ b/internal/provider/vulnerability_policy_resource_test.go
@@ -9,6 +9,9 @@ import (
 
 // API 5+.
 func TestAccVulnerabilityPolicyResource(t *testing.T) {
+	if apiSemver.Major < 5 {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -83,6 +86,9 @@ resource "dependencytrack_vulnerability_policy" "test" {
 
 func TestAccVulnerabilityPolicyResourceRegression236(t *testing.T) {
 	// Regression test for https://github.com/SolarFactories/terraform-provider-dependencytrack/issues/236
+	if apiSemver.Major < 5 {
+		t.SkipNow()
+	}
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
- Add obtaining of API Semver within tests.
- Add conditions to individual tests for disabling against API versions.
  - Enabling running of tests locally, to only run the tests that are using compatible resources, and are expected to pass.
- Remove skip field within pipeline, as it is no longer required, and only adds maintenance burden as new v5 only tests are added.